### PR TITLE
Adding code to support legacy sign

### DIFF
--- a/LegacySignController/.gitignore
+++ b/LegacySignController/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/LegacySignController/.vscode/extensions.json
+++ b/LegacySignController/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/LegacySignController/.vscode/settings.json
+++ b/LegacySignController/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": true
+}

--- a/LegacySignController/include/README
+++ b/LegacySignController/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/LegacySignController/platformio.ini
+++ b/LegacySignController/platformio.ini
@@ -1,0 +1,21 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:nanorp2040connect]
+platform = raspberrypi
+board = nanorp2040connect
+framework = arduino
+lib_deps = 
+	arduino-libraries/ArduinoBLE@^1.3.6
+	https://github.com/avishorp/TM1637#v1.2.0
+	adafruit/Adafruit NeoPixel@^1.12.0
+
+[platformio]
+lib_dir = ../lib

--- a/LegacySignController/src/main.cpp
+++ b/LegacySignController/src/main.cpp
@@ -1,0 +1,349 @@
+#include "main.h"
+
+// TODO reminders:
+// - Merge new pattern data into sign status (sign status has brightness and speed)
+// - Setup predefined styles here instead of in Secondary
+// - Clean up deprecated secondary characteristics from CommonPeripheral, move to new PrimaryPeripheral.
+// - Have manual buttons detect a sequence of presses (ie, allow user to cylce though a bunch of styles).
+// - (Still TBD) Enable a separate pattern for the logo
+
+// Global variables
+CommonPeripheral btService;
+StatusDisplay display(TM1637_CLOCK, TM1637_DIO, TM1637_BRIGHTNESS);
+PixelBuffer pixelBuffer(DATA_OUT);
+DisplayPattern* currentLightStyle;
+
+std::vector<PushButton *> manualInputButtons;
+PredefinedStyleList* predefinedStyleList;
+ulong loopCounter = 0;
+ulong lastTelemetryTimestamp = 0;
+
+int lastManualButtonPressed = -1;
+int manualButtonSequenceNumber = 0;
+byte inLowPowerMode = false;              // Indicates the system should be in "low power" mode. This should be a boolean, but there are no bool types.
+
+PredefinedStyle defaultStyle = PredefinedStyle::getPredefinedStyle(PredefinedStyles::Pink_Solid);
+
+// Settings that are updated via bluetooth
+byte currentBrightness = DEFAULT_BRIGHTNESS;
+byte newBrightness = DEFAULT_BRIGHTNESS;
+byte currentSpeed;
+byte newSpeed;
+PatternData currentPatternData;
+PatternData newPatternData;
+
+void setup()
+{
+    Serial.begin(9600);
+    delay(500);
+    Serial.println("Starting...");
+
+    std::vector<int> manualInputPins{MANUAL_INPUT_PINS};
+    for (uint i = 0; i < manualInputPins.size(); i++)
+    {
+        manualInputButtons.push_back(new PushButton(manualInputPins[i], INPUT_PULLUP));
+    }
+
+    initializeIO();
+
+    if (digitalRead(LOW_BRIGHTNESS_PIN) == LOW)
+    {
+        currentBrightness = DEFAULT_BRIGHTNESS_LOW;
+        newBrightness = DEFAULT_BRIGHTNESS_LOW;
+    }
+
+    display.setDisplay("----");
+    setupStyleLists();
+    pixelBuffer.initialize(LEGACY_SIGN_TYPE);
+
+    if (!BLE.begin())
+    {
+        Serial.println("BLE initialization failed!");
+        display.setDisplay("E1");
+        while (true)
+        {
+        }
+    }
+
+    startBLEService();
+}
+
+void loop()
+{
+    BLE.poll();
+    display.update();
+    updateTelemetry();
+    checkForLowPowerState();
+
+    if (inLowPowerMode)
+    {
+        // blink LEDs and exit.
+        blinkLowPowerIndicator();
+        return;
+    }
+
+    if (btService.isConnected())
+    {
+        // Something is connected via BT.
+        // Set the display to "--" to show something connected to us.
+        // Display it as "temporary" since it's a low-priority message.
+        display.displayTemporary(" --", 500);
+    }
+
+    readSettingsFromBLE();
+    updateInputButtons();
+    processManualInputs();
+    updateLEDs();
+}
+
+void processManualInputs()
+{
+    // First look for any long-presses that happened.
+    // If button 1 (id 0) was long-pressed, display battery voltages for the clients.
+    if (manualInputButtons[0]->wasPressed() && manualInputButtons[0]->lastPressType() == ButtonPressType::Long)
+    {
+        manualInputButtons[0]->clearPress();
+        displayBatteryVoltage();
+    }
+
+    // If button 3 (id 2) was long-pressed, force-disconnect any BT clients.
+    if (manualInputButtons[2]->wasPressed() && manualInputButtons[2]->lastPressType() == ButtonPressType::Long)
+    {
+        manualInputButtons[2]->clearPress();
+        btService.disconnect();
+    }
+
+    // Next look for any button presses that indicate style changes.
+    // If the same button was pressed previously, cycle through the styles.
+    for (uint i = 0; i < manualInputButtons.size(); i++)
+    {
+        if (manualInputButtons[i]->wasPressed() && manualInputButtons[i]->lastPressType() == ButtonPressType::Normal)
+        {
+            if ((int)i == lastManualButtonPressed)
+            {
+                // This button was pressed last time -- cycle through the sequence.
+                manualButtonSequenceNumber++;
+            }
+            else
+            {
+                manualButtonSequenceNumber = 0;
+            }
+
+            // Get the vector corresponding to the button number (4 vectors; 1 per button),
+            // then get the style by indexing into the vector.
+            PredefinedStyle selectedStyle = predefinedStyleList->getStyle(i, manualButtonSequenceNumber);
+            setManualStyle(selectedStyle);
+            manualInputButtons[i]->clearPress();
+            lastManualButtonPressed = i;
+        }
+    }
+}
+
+void setManualStyle(PredefinedStyle style)
+{
+    newSpeed = style.getSpeed();
+    newPatternData = style.getPatternData();
+
+    // Update the local BLE settings to reflect the new manual settings.
+    btService.setSpeed(newSpeed);
+    btService.setPatternData(newPatternData);
+}
+
+void updateInputButtons()
+{
+    for (uint i = 0; i < manualInputButtons.size(); i++)
+    {
+        manualInputButtons[i]->update();
+    }
+}
+
+void startBLEService()
+{
+    display.setDisplay("C  =");
+    Serial.println("Setting up Peripheral service using common logic.");
+    String localName = "3181 LED Legacy Controller";
+    btService.initialize(BTCOMMON_PRIMARYCONTROLLER_UUID, localName);
+
+    // Set the various characteristics based on the defaults
+    display.setDisplay("C ==");
+
+    btService.setBrightness(newBrightness);
+    btService.setSpeed(defaultStyle.getSpeed());
+    btService.setPatternData(defaultStyle.getPatternData());
+    btService.setColorPatternList(PatternFactory::getKnownColorPatterns());
+    btService.setDisplayPatternList(PatternFactory::getKnownDisplayPatterns());
+
+    Serial.println("Peripheral service started.");
+    display.clear();
+}
+
+void readSettingsFromBLE()
+{
+    newBrightness = btService.getBrightness();
+    newSpeed = btService.getSpeed();
+    newPatternData = btService.getPatternData();
+}
+
+void setupStyleLists()
+{
+    predefinedStyleList = new PredefinedStyleList(manualInputButtons.size());
+
+    // Styles for button 1 (id 0)
+    predefinedStyleList->addStyleToList(0, PredefinedStyles::Pink_Solid);
+    predefinedStyleList->addStyleToList(0, PredefinedStyles::Rainbow_Right);
+
+    // Styles for button 2 (id 1)
+    predefinedStyleList->addStyleToList(1, PredefinedStyles::RedPink_Right);
+    predefinedStyleList->addStyleToList(1, PredefinedStyles::RedPink_CenterOut);
+
+    // Styles for button 3 (id 2)
+    predefinedStyleList->addStyleToList(1, PredefinedStyles::BluePink_Right);
+    predefinedStyleList->addStyleToList(1, PredefinedStyles::BluePink_CenterOut);
+}
+
+void initializeIO()
+{
+    pinMode(VOLTAGEINPUTPIN, INPUT);
+    pinMode(LOW_BRIGHTNESS_PIN, INPUT_PULLUP);
+}
+
+// Read the analog input from the "voltage input" pin and calculate the batter voltage.
+float getCalculatedBatteryVoltage()
+{
+    // The analog input ranges from 0 (0V) to 1024 (3.3V), resulting in 0.00322 Volts per "tick".
+    // The battery voltage passes through a voltage divider such that the voltage at the input
+    // is 1/3 of the actual battery voltage.
+    float rawLevel = getVoltageInputLevel();
+    return rawLevel * 3 * 3.3 / 1024;
+}
+
+// Read the raw value from the "voltage input" pin.
+int getVoltageInputLevel()
+{
+    return analogRead(VOLTAGEINPUTPIN);
+}
+
+void displayBatteryVoltage()
+{
+    double voltage = getCalculatedBatteryVoltage();
+    display.displayTemporary(String(voltage, 2), 1500);
+}
+
+// Check if the current battery voltage is too low to run the sign,
+// or if the battery has been charged enough to restart operation.
+void checkForLowPowerState()
+{
+    double currentVoltage = getCalculatedBatteryVoltage();
+
+    // Check if the voltage is too low.
+    if (currentVoltage < LOWPOWERTHRESHOLD)
+    {
+        if (inLowPowerMode)
+        {
+            // Already in low power mode - nothing to do.
+        }
+        else
+        {
+            Serial.print("Battery voltage is below threshold. Voltage: ");
+            Serial.print(currentVoltage);
+            Serial.print(", threshold: ");
+            Serial.println(LOWPOWERTHRESHOLD);
+            Serial.println("Entering low power mode.");
+            inLowPowerMode = true;
+        }
+    }
+
+    // Check if the voltage is high enough for normal operation.
+    if (currentVoltage > NORMALPOWERTHRESHOLD)
+    {
+        if (!inLowPowerMode)
+        {
+            // Not in low power mode - nothing to do.
+        }
+        else
+        {
+            Serial.print("Battery voltage is above normal threshold. Voltage: ");
+            Serial.print(currentVoltage);
+            Serial.print(", threshold: ");
+            Serial.println(NORMALPOWERTHRESHOLD);
+            Serial.println("Exiting low power mode.");
+            pixelBuffer.setBrightness(currentBrightness);
+            inLowPowerMode = false;
+        }
+    }
+}
+
+void updateTelemetry()
+{
+    loopCounter++;
+    unsigned long timestamp = millis();
+
+    if (timestamp > lastTelemetryTimestamp + TELEMETRYINTERVAL)
+    {
+        // Calculate loop timing data
+        unsigned long diff = timestamp - lastTelemetryTimestamp;
+        double timePerIteration = (double)diff / loopCounter;
+        Serial.print(loopCounter);
+        Serial.print(" iterations done in ");
+        Serial.print(diff);
+        Serial.print(" msec; avg msec per iteration: ");
+        Serial.println(timePerIteration);
+        lastTelemetryTimestamp = timestamp;
+        loopCounter = 0;
+
+        // Output voltage info periodically
+        int rawLevel = getVoltageInputLevel();
+        float voltage = getCalculatedBatteryVoltage();
+
+        // Emit battery voltage information on Bluetooth as well as Serial.
+        btService.emitBatteryVoltage(voltage);
+        Serial.print("Analog input: ");
+        Serial.print(rawLevel);
+        Serial.print("; calculated voltage: ");
+        Serial.println(voltage);
+    }
+}
+
+void updateLEDs()
+{
+    if (newBrightness != currentBrightness)
+    {
+        pixelBuffer.setBrightness(newBrightness);
+        currentBrightness = newBrightness;
+    }
+
+    if (currentPatternData != newPatternData)
+    {
+        if (currentLightStyle)
+        {
+            delete currentLightStyle;
+        }
+
+        currentLightStyle = PatternFactory::createForPatternData(newPatternData, &pixelBuffer);
+        currentLightStyle->setSpeed(newSpeed);
+        currentLightStyle->reset();
+
+        currentPatternData = newPatternData;
+    }
+
+    // The current style shouldn't ever be null here, but check anyways.
+    if (currentLightStyle)
+    {
+        currentLightStyle->update();
+    }
+
+    pixelBuffer.displayPixels();    
+}
+
+void blinkLowPowerIndicator()
+{
+    // Turn all LEDs off except for the first one, which will blink red.
+    pixelBuffer.setBrightness(255);
+    pixelBuffer.clearBuffer();
+    pixelBuffer.displayPixels();
+    delay(500);
+
+    pixelBuffer.setPixel(0, Adafruit_NeoPixel::Color(255, 0, 0));
+    pixelBuffer.displayPixels();
+    delay(500);
+}

--- a/LegacySignController/src/main.cpp
+++ b/LegacySignController/src/main.cpp
@@ -55,6 +55,7 @@ void setup()
     display.setDisplay("----");
     setupStyleLists();
     pixelBuffer.initialize(LEGACY_SIGN_TYPE);
+    pixelBuffer.setBrightness(currentBrightness);
 
     if (!BLE.begin())
     {
@@ -167,7 +168,7 @@ void startBLEService()
     // Set the various characteristics based on the defaults
     display.setDisplay("C ==");
 
-    btService.setBrightness(newBrightness);
+    btService.setBrightness(currentBrightness);
     btService.setSpeed(defaultStyle.getSpeed());
     btService.setPatternData(defaultStyle.getPatternData());
     btService.setColorPatternList(PatternFactory::getKnownColorPatterns());
@@ -197,8 +198,8 @@ void setupStyleLists()
     predefinedStyleList->addStyleToList(1, PredefinedStyles::RedPink_CenterOut);
 
     // Styles for button 3 (id 2)
-    predefinedStyleList->addStyleToList(1, PredefinedStyles::BluePink_Right);
-    predefinedStyleList->addStyleToList(1, PredefinedStyles::BluePink_CenterOut);
+    predefinedStyleList->addStyleToList(2, PredefinedStyles::BluePink_Right);
+    predefinedStyleList->addStyleToList(2, PredefinedStyles::BluePink_CenterOut);
 }
 
 void initializeIO()

--- a/LegacySignController/src/main.h
+++ b/LegacySignController/src/main.h
@@ -1,0 +1,45 @@
+#include <Arduino.h>
+#include <ArduinoBLE.h>
+#include <vector>
+#include <algorithm>
+#include <BluetoothCommon.h>
+#include <DisplayPatternLib.h>
+#include <PushButton.h>
+#include <StatusDisplay.h>
+#include <PredefinedStyleLib.h>
+
+#define DATA_OUT 25            // GPIO pin # (NOT Digital pin #) controlling the NeoPixels
+#define VOLTAGEINPUTPIN 16     // The pin # (Digital #) for the analog input to detect battery voltage level.
+
+#define TM1637_CLOCK 8    // Digital pin # for the TM1637 clock line
+#define TM1637_DIO 7      // Digital pin # for the TM1637 data line
+#define TM1637_BRIGHTNESS 5  // Brightness of the TM1637, between 0 and 7
+
+#define LOWPOWERTHRESHOLD 5.9     // The voltage below which the system will go into "low power" mode.
+#define NORMALPOWERTHRESHOLD 6.9  // The voltage above which the system will recover from "low power" mode.
+
+#define MANUAL_INPUT_PINS 15, 9, 14      // Digital pin #s for the manual input buttons.
+
+#define TELEMETRYINTERVAL 2000     // Interval (msec) for updating the telemetry.
+
+#define DEFAULT_BRIGHTNESS 255  // Brightness should be between 0 and 255.
+#define LOW_BRIGHTNESS_PIN  12  // When this Digital pin # is pulled low, the default brightness will be much lower than normal.
+#define DEFAULT_BRIGHTNESS_LOW 20 // The default brightness to use when the "Low Brightness" pin has been pulled low.
+
+#define LEGACY_SIGN_TYPE 16     // The "sign type" corresponding to the Legacy sign, used to initialize the pixel buffer.
+
+// Function prototypes
+void initializeIO();
+void setupStyleLists();
+void startBLEService();
+void readSettingsFromBLE();
+void processManualInputs();
+void updateInputButtons();
+void setManualStyle(PredefinedStyle style);
+void updateTelemetry();
+float getCalculatedBatteryVoltage();
+int getVoltageInputLevel();
+void displayBatteryVoltage();
+void checkForLowPowerState();
+void blinkLowPowerIndicator();
+void updateLEDs();

--- a/LegacySignController/test/README
+++ b/LegacySignController/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html

--- a/lib/PixelBuffer/PixelBuffer.cpp
+++ b/lib/PixelBuffer/PixelBuffer.cpp
@@ -29,6 +29,9 @@ void PixelBuffer::initialize(byte signStyle)
         case 8:
             initializeDigitEight();
             break;
+        case 16:
+            initializeOldSign();
+            break;
         default:
             initializeTestMatrix();
     }


### PR DESCRIPTION
Adding support for the legacy sign.
A bit of a hack...  The code is a cross between the Primary and Secondary controller projects.  It acts like a Primary since it has its own manual style buttons and status display, but it also acts like a Secondary since it needs to actually drive pixels and monitor battery voltage.

Pinout:
- DataOut = GPIO25 (Same as secondary controller)
- BatteryIn = A2/D16
- TM1637 display clk/data = D8/D7 (Same as primary controller)
- Manual display buttons = D15/D9/D14 (Same as primary controller)