### PR TITLE
Code optimizations, non-blocking blink pattern

### DIFF
--- a/LegacySignController/src/main.cpp
+++ b/LegacySignController/src/main.cpp
@@ -82,7 +82,7 @@ void loop()
         // Something is connected via BT.
         // Set the display to "--" to show something connected to us.
         // Display it as "temporary" since it's a low-priority message.
-        display.displayTemporary(" --", 500);
+        display.displayTemporary(" --", 200);
     }
 
     if (!inLowPowerMode)

--- a/LegacySignController/src/main.cpp
+++ b/LegacySignController/src/main.cpp
@@ -318,6 +318,16 @@ void updateLEDs()
         currentBrightness = newBrightness;
     }
 
+    if (newSpeed != currentSpeed)
+    {
+        if (currentLightStyle)
+        {
+            currentLightStyle->setSpeed(newSpeed);
+        }
+        
+        currentSpeed = newSpeed;
+    }
+
     if (currentPatternData != newPatternData)
     {
         if (currentLightStyle)

--- a/LegacySignController/src/main.cpp
+++ b/LegacySignController/src/main.cpp
@@ -17,11 +17,10 @@ std::vector<PushButton *> manualInputButtons;
 PredefinedStyleList* predefinedStyleList;
 ulong loopCounter = 0;
 ulong lastTelemetryTimestamp = 0;
-ulong lastConnectionCheck = 0;
 
 int lastManualButtonPressed = -1;
 int manualButtonSequenceNumber = 0;
-byte inLowPowerMode = false;              // Indicates the system should be in "low power" mode. This should be a boolean, but there are no bool types.
+byte inLowPowerMode = false;          // Indicates the system should be in "low power" mode. This should be a boolean, but there are no bool types.
 
 PredefinedStyle defaultStyle = PredefinedStyle::getPredefinedStyle(PredefinedStyles::Pink_Solid);
 
@@ -84,16 +83,12 @@ void loop()
         return;
     }
 
-    if (btService.isConnected() && millis() > lastConnectionCheck + BTCHECKINTERVAL)
+    if (btService.isConnected())
     {
         // Something is connected via BT.
         // Set the display to "--" to show something connected to us.
         // Display it as "temporary" since it's a low-priority message.
-        // Updating the display takes about 30 msec.  Doing it on every iteration
-        // will have a very noticable effect on the LED updates, so only
-        // re-update the display every half second or so.
-        display.displayTemporary(" --", BTCHECKINTERVAL + 50);
-        lastConnectionCheck = millis();
+        display.displayTemporary(" --", 500);
     }
 
     readSettingsFromBLE();

--- a/LegacySignController/src/main.h
+++ b/LegacySignController/src/main.h
@@ -28,7 +28,6 @@
 #define DEFAULT_BRIGHTNESS_LOW 20 // The default brightness to use when the "Low Brightness" pin has been pulled low.
 
 #define LEGACY_SIGN_TYPE 16     // The "sign type" corresponding to the Legacy sign, used to initialize the pixel buffer.
-#define BTCHECKINTERVAL 500     // The amount of time, in msec, between checks to see if we need to set the display to indicate a BT connection.
 
 // Function prototypes
 void initializeIO();

--- a/SecondaryController/src/main.h
+++ b/SecondaryController/src/main.h
@@ -11,6 +11,7 @@
 #include <SignDataLib.h>
 #include <PatternData.h>
 #include <DisplayPatternLib.h>
+#include <PredefinedStyleLib.h>
 
 // Input-Output pin assignments
 #define DATA_OUT 25            // GPIO pin # (NOT Digital pin #) controlling the NeoPixels

--- a/lib/DisplayPatternLib/LowPowerDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/LowPowerDisplayPattern.cpp
@@ -1,0 +1,37 @@
+#include "LowPowerDisplayPattern.h"
+
+LowPowerDisplayPattern::LowPowerDisplayPattern(PixelBuffer* pixelBuffer) : DisplayPattern(pixelBuffer)
+{
+}
+
+void LowPowerDisplayPattern::resetInternal()
+{
+    m_iterationCount = 0;
+    m_colorPattern->reset();
+    
+    // Fill the buffer with black
+    m_pixelBuffer->fill(0);
+}
+
+void LowPowerDisplayPattern::updateInternal()
+{
+    // We're just emitting a single blinking pixel.
+    // Instead of calling m_colorPattern->getNextColor() each time,
+    // alternate between setting all to black and setting the first pixel
+    // to the "next color" from the pattern (which should normally be just a solid color).
+    if (m_iterationCount % 2 == 0)
+    {
+        m_pixelBuffer->setPixel(0, m_colorPattern->getNextColor());
+    }
+    else
+    {
+        m_pixelBuffer->setPixel(0, 0);
+    }
+    
+    m_iterationCount++;    
+}
+
+std::vector<String> LowPowerDisplayPattern::getParameterNames()
+{
+    return std::vector<String>();
+}

--- a/lib/DisplayPatternLib/LowPowerDisplayPattern.h
+++ b/lib/DisplayPatternLib/LowPowerDisplayPattern.h
@@ -1,0 +1,23 @@
+#ifndef LOWPOWERDISPLAYPATTERN_H
+#define LOWPOWERDISPLAYPATTERN_H
+
+#include <Arduino.h>
+#include "DisplayPattern.h"
+#include "PixelBuffer.h"
+
+class LowPowerDisplayPattern : public DisplayPattern
+{
+    public:
+        LowPowerDisplayPattern(PixelBuffer* pixelBuffer);
+
+        static std::vector<String> getParameterNames();
+
+    protected:
+        virtual void updateInternal();
+        virtual void resetInternal();
+
+    private:
+        uint m_iterationCount{0};
+};
+
+#endif

--- a/lib/DisplayPatternLib/PatternFactory.cpp
+++ b/lib/DisplayPatternLib/PatternFactory.cpp
@@ -17,6 +17,13 @@ DisplayPattern* PatternFactory::createForPatternData(const PatternData& patternD
 
     switch (patternData.displayPattern)
     {
+        case DisplayPatternType::LowPower:
+        {
+            LowPowerDisplayPattern* pattern = new LowPowerDisplayPattern(pixelBuffer);
+            pattern->setColorPattern(colorPattern);
+            displayPattern = pattern;
+            break;
+        }
         case DisplayPatternType::Up:
         {
             SimpleShiftDisplayPattern* pattern = new SimpleShiftDisplayPattern(ShiftType::Up, pixelBuffer);

--- a/lib/DisplayPatternLib/PatternFactory.h
+++ b/lib/DisplayPatternLib/PatternFactory.h
@@ -7,6 +7,7 @@
 #include "SimpleShiftDisplayPattern.h"
 #include "RandomDisplayPattern.h"
 #include "CenterOutDisplayPattern.h"
+#include "LowPowerDisplayPattern.h"
 #include <ColorPatternLib.h>
 #include "PixelBuffer.h"
 #include <PatternData.h>

--- a/lib/PatternData/DisplayPatternType.h
+++ b/lib/PatternData/DisplayPatternType.h
@@ -14,7 +14,8 @@ enum class DisplayPatternType : byte
     Random = 6,
 	CenterOutVertical = 7,
 	CenterOutHorizontal = 8,
-	Line = 9
+	Line = 9,
+    LowPower = 10
 };
 
 #endif

--- a/lib/PredefinedStyleLib/PredefinedStyle.cpp
+++ b/lib/PredefinedStyleLib/PredefinedStyle.cpp
@@ -46,6 +46,14 @@ PredefinedStyle PredefinedStyle::getPredefinedStyle(PredefinedStyles styleName)
 
     switch (styleName)
     {
+        case PredefinedStyles::LowPower:
+        {
+            PatternData pattern;
+            pattern.colorPattern = ColorPatternType::SingleColor;
+            pattern.displayPattern = DisplayPatternType::LowPower;
+            pattern.color1 = Red;
+            return PredefinedStyle{"Low Power", 1, pattern};
+        }
         case PredefinedStyles::Pink_Solid:
         {
             PatternData pattern;

--- a/lib/PredefinedStyleLib/PredefinedStyles.h
+++ b/lib/PredefinedStyleLib/PredefinedStyles.h
@@ -2,6 +2,7 @@
 #define PREDEFINEDSTYLES_H
 
 enum class PredefinedStyles {
+    LowPower,
     Pink_Solid,
     RedPink_Right,
     BluePink_Right,

--- a/lib/StatusDisplay/StatusDisplay.cpp
+++ b/lib/StatusDisplay/StatusDisplay.cpp
@@ -106,6 +106,12 @@ void StatusDisplay::displaySequence(std::vector<String> stringsToDisplay, uint d
 
 void StatusDisplay::displayString(String s)
 {
+    if (m_lastDisplayString.equals(s))
+    {
+        // Already displaying this string.
+        return;
+    }
+
     byte tempBuffer[4]{0, 0, 0, 0};
 
     // Convert characters until we run out or hit 4 characters.
@@ -135,6 +141,7 @@ void StatusDisplay::displayString(String s)
     }
 
     m_display->setSegments(tempBuffer);
+    m_lastDisplayString = s;
 }
 
 byte StatusDisplay::convertCharacter(char c)

--- a/lib/StatusDisplay/StatusDisplay.cpp
+++ b/lib/StatusDisplay/StatusDisplay.cpp
@@ -26,8 +26,7 @@ void StatusDisplay::update()
     {
         if (m_currentPriority == DisplayPriority::Ephemeral)
         {
-            m_display->clear();
-            m_currentPriority = DisplayPriority::None;
+            clear();
         }
         else if (m_currentPriority == DisplayPriority::Sequence)
         {
@@ -39,8 +38,7 @@ void StatusDisplay::update()
             }
             else
             {
-                m_display->clear();
-                m_currentPriority = DisplayPriority::None;
+                clear();
             }
         }
     }
@@ -49,6 +47,7 @@ void StatusDisplay::update()
 void StatusDisplay::clear()
 {
     m_display->clear();
+    m_lastDisplayString = "";
     m_currentPriority = DisplayPriority::None;
 }
 

--- a/lib/StatusDisplay/StatusDisplay.h
+++ b/lib/StatusDisplay/StatusDisplay.h
@@ -52,6 +52,7 @@ class StatusDisplay {
         byte convertCharacter(char c);
         void displayString(String s);
 
+        String m_lastDisplayString;
         ulong m_nextUpdate{0};
         uint m_sequenceDuration{0};
         DisplayPriority m_currentPriority{DisplayPriority::None};


### PR DESCRIPTION
Don't update the status display if the string didn't change.
Move the blinking "low power" indicator to a display pattern so it's no longer blocking.