### PR TITLE
Add dual core support for Legacy sign controller

### DIFF
--- a/LegacySignController/platformio.ini
+++ b/LegacySignController/platformio.ini
@@ -9,13 +9,14 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:nanorp2040connect]
-platform = raspberrypi
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = nanorp2040connect
 framework = arduino
+board_build.core = earlephilhower
 lib_deps = 
 	https://github.com/avishorp/TM1637#v1.2.0
-	adafruit/Adafruit NeoPixel@^1.12.0
-	arduino-libraries/ArduinoBLE@^1.3.7
+	arduino-libraries/ArduinoBLE@^1.3.6
+	adafruit/Adafruit NeoPixel@^1.12.3
 
 [platformio]
 lib_dir = ../lib

--- a/LegacySignController/src/main.cpp
+++ b/LegacySignController/src/main.cpp
@@ -27,6 +27,8 @@ byte newSpeed;
 PatternData currentPatternData;
 PatternData newPatternData;
 
+volatile bool isInitialized = false;
+
 void setup()
 {
     Serial.begin(9600);
@@ -64,6 +66,7 @@ void setup()
     }
 
     startBLEService();
+    isInitialized = true;
 }
 
 void loop()
@@ -89,6 +92,20 @@ void loop()
         processManualInputs();
     }
 
+    // moved the LED update to the second core
+    // updateLEDs();
+}
+
+// Setup for the second core
+void setup1()
+{
+    while(!isInitialized) {}
+}
+
+// Main loop for the second core
+void loop1()
+{
+    // Check for threading issues!!!
     updateLEDs();
 }
 

--- a/LegacySignController/src/main.h
+++ b/LegacySignController/src/main.h
@@ -10,22 +10,22 @@
 #include <PixelBufferLib.h>
 
 #define DATA_OUT 25            // GPIO pin # (NOT Digital pin #) controlling the NeoPixels
-#define VOLTAGEINPUTPIN 17     // The pin # (Digital #) for the analog input to detect battery voltage level.
+#define VOLTAGEINPUTPIN 29     // The pin # (Digital #) for the analog input to detect battery voltage level.
 
-#define TM1637_CLOCK 11    // Digital pin # for the TM1637 clock line
-#define TM1637_DIO 10      // Digital pin # for the TM1637 data line
+#define TM1637_CLOCK 7    // Digital pin # for the TM1637 clock line
+#define TM1637_DIO 5      // Digital pin # for the TM1637 data line
 #define TM1637_BRIGHTNESS 5  // Brightness of the TM1637, between 0 and 7
 
 #define LOWPOWERTHRESHOLD 6.7     // The voltage below which the system will go into "low power" mode.
 #define NORMALPOWERTHRESHOLD 7.2  // The voltage above which the system will recover from "low power" mode.
 #define VOLTAGEMULTIPLIER 4.83    // The value to multiply the analog reading by to get the actual voltage.
 
-#define MANUAL_INPUT_PINS 15, 16, 14      // Digital pin #s for the manual input buttons.
+#define MANUAL_INPUT_PINS 27, 28, 26      // Digital pin #s for the manual input buttons.
 
 #define TELEMETRYINTERVAL 2000     // Interval (msec) for updating the telemetry.
 
 #define DEFAULT_BRIGHTNESS 255  // Brightness should be between 0 and 255.
-#define LOW_BRIGHTNESS_PIN  12  // When this Digital pin # is pulled low, the default brightness will be much lower than normal.
+#define LOW_BRIGHTNESS_PIN  4  // When this Digital pin # is pulled low, the default brightness will be much lower than normal.
 #define DEFAULT_BRIGHTNESS_LOW 20 // The default brightness to use when the "Low Brightness" pin has been pulled low.
 
 #define LEGACY_SIGN_TYPE 16     // The "sign type" corresponding to the Legacy sign, used to initialize the pixel buffer.

--- a/LegacySignController/src/main.h
+++ b/LegacySignController/src/main.h
@@ -10,22 +10,22 @@
 #include <PixelBufferLib.h>
 
 #define DATA_OUT 25            // GPIO pin # (NOT Digital pin #) controlling the NeoPixels
-#define VOLTAGEINPUTPIN 29     // The pin # (Digital #) for the analog input to detect battery voltage level.
+#define VOLTAGEINPUTPIN 29     // GPIO pin # for the analog input to detect battery voltage level.
 
-#define TM1637_CLOCK 7    // Digital pin # for the TM1637 clock line
-#define TM1637_DIO 5      // Digital pin # for the TM1637 data line
+#define TM1637_CLOCK 7    // GPIO pin # for the TM1637 clock line
+#define TM1637_DIO 5      // GPIO pin # for the TM1637 data line
 #define TM1637_BRIGHTNESS 5  // Brightness of the TM1637, between 0 and 7
 
 #define LOWPOWERTHRESHOLD 6.7     // The voltage below which the system will go into "low power" mode.
 #define NORMALPOWERTHRESHOLD 7.2  // The voltage above which the system will recover from "low power" mode.
 #define VOLTAGEMULTIPLIER 4.83    // The value to multiply the analog reading by to get the actual voltage.
 
-#define MANUAL_INPUT_PINS 27, 28, 26      // Digital pin #s for the manual input buttons.
+#define MANUAL_INPUT_PINS 27, 28, 26      // GPIO pin #s for the manual input buttons.
 
 #define TELEMETRYINTERVAL 2000     // Interval (msec) for updating the telemetry.
 
 #define DEFAULT_BRIGHTNESS 255  // Brightness should be between 0 and 255.
-#define LOW_BRIGHTNESS_PIN  4  // When this Digital pin # is pulled low, the default brightness will be much lower than normal.
+#define LOW_BRIGHTNESS_PIN  4  // When this GPIO pin # is pulled low, the default brightness will be much lower than normal.
 #define DEFAULT_BRIGHTNESS_LOW 20 // The default brightness to use when the "Low Brightness" pin has been pulled low.
 
 #define LEGACY_SIGN_TYPE 16     // The "sign type" corresponding to the Legacy sign, used to initialize the pixel buffer.


### PR DESCRIPTION
Moving the LED sign update logic to the second core of the RP2040, freeing up the first core for BLE processing.