### PR TITLE
Adding a Rotation Swipe display pattern

### DIFF
--- a/lib/DisplayPatternLib/src/DisplayPatterns/RotationDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/RotationDisplayPattern.cpp
@@ -54,9 +54,16 @@ void RotationDisplayPattern::updateInternal()
                 angleToPixelDeg += 360.0f;
             }
 
-            if (isAngleInRange(angleToPixelDeg, m_currentAngleDeg, newAngleDeg))
+            float rayAngleIncrement = 360.0f / m_numberOfRays;
+            for (uint rayIndex = 0; rayIndex < m_numberOfRays; rayIndex++)
             {
-                m_pixelBuffer->setColorInPixelMap(row, col, currentColor);
+                float adjustedStartAngle = m_currentAngleDeg + rayIndex * rayAngleIncrement;
+                float adjustedEndAngle = newAngleDeg + rayIndex * rayAngleIncrement;
+
+                if (isAngleInRange(angleToPixelDeg, adjustedStartAngle, adjustedEndAngle))
+                {
+                    m_pixelBuffer->setColorInPixelMap(row, col, currentColor);
+                }
             }
         }
     }
@@ -72,19 +79,34 @@ void RotationDisplayPattern::updateInternal()
     }
 }
 
+// This method assumes that endAngle = startAngle +/- some increment.
+// It assumes that no angle-wrapping has been applied to the start or end angles.
 boolean RotationDisplayPattern::isAngleInRange(float angleToCheck, float startAngle, float endAngle)
 {
-    if (startAngle < endAngle)
+    float normalizedStartAngle = startAngle;
+    float normalizedEndAngle = endAngle;
+
+    if (startAngle > 360.0f && endAngle > 360.0f)
+    {
+        normalizedStartAngle -= 360.0f;
+        normalizedEndAngle -= 360.0f;
+    }
+    if (startAngle < 0.0f && endAngle < 0.0f)
+    {
+        normalizedStartAngle += 360.0f;
+        normalizedEndAngle += 360.0f;
+    }
+    if (normalizedStartAngle < normalizedEndAngle)
     {
         // angle is increasing
-        if (angleToCheck >= startAngle && angleToCheck < endAngle)
+        if (angleToCheck >= normalizedStartAngle && angleToCheck < normalizedEndAngle)
         {
             return true;
         }
         // Check if we've wrapped around past 360 degrees
-        if (endAngle >= 360.0f)
+        if (normalizedEndAngle >= 360.0f)
         {
-            if (angleToCheck + 360 >= startAngle && angleToCheck + 360 < endAngle)
+            if (angleToCheck + 360 >= normalizedStartAngle && angleToCheck + 360 < normalizedEndAngle)
             {
                 return true;
             }
@@ -93,14 +115,14 @@ boolean RotationDisplayPattern::isAngleInRange(float angleToCheck, float startAn
     else
     {
         // angle is decreasing
-        if (angleToCheck <= startAngle && angleToCheck > endAngle)
+        if (angleToCheck <= normalizedStartAngle && angleToCheck > normalizedEndAngle)
         {
             return true;
         }
         // Check if we've wrapped around past 0 degrees
-        if (endAngle < 0.0f)
+        if (normalizedEndAngle < 0.0f)
         {
-            if (angleToCheck - 360 <= startAngle && angleToCheck - 360 > endAngle)
+            if (angleToCheck - 360 <= normalizedStartAngle && angleToCheck - 360 > normalizedEndAngle)
             {
                 return true;
             }

--- a/lib/DisplayPatternLib/src/DisplayPatterns/RotationDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/RotationDisplayPattern.cpp
@@ -1,0 +1,121 @@
+#include "RotationDisplayPattern.h"
+
+RotationDisplayPattern::RotationDisplayPattern(boolean isClockwise, PixelBuffer *pixelBuffer) : DisplayPattern(pixelBuffer), m_isClockwise(isClockwise)
+{
+    m_isClockwise = isClockwise;
+}
+
+void RotationDisplayPattern::setNumberOfRays(byte unscaledValue)
+{
+    int numberOfRays = MathUtils::rescaleInput(1, 5, unscaledValue);
+    if (numberOfRays > 4)
+    {
+        numberOfRays = 4;
+    }
+
+    m_numberOfRays = numberOfRays;
+}
+
+void RotationDisplayPattern::setAngleIncrementDeg(byte unscaledValue)
+{
+    m_angleIncrementDeg = MathUtils::rescaleInput(1, 15, unscaledValue);
+}
+
+void RotationDisplayPattern::resetInternal()
+{
+    m_colorPattern->reset();
+
+    // Calculate center point
+    // TODO: take into account offsets for columns to left/right
+    m_centerRow = m_pixelBuffer->getRowCount() / 2.0f;
+    m_centerColumn = m_pixelBuffer->getColumnCount() / 2.0f;
+}
+
+void RotationDisplayPattern::updateInternal()
+{
+    // Hard code 1 degree per update for now.
+    // Only 1 "ray" for now.
+
+    // Due to the fact that the pixel buffer's row and column numbers start
+    // at 0 in the top-left, an increasing angle is clockwise.
+    float newAngleDeg = m_isClockwise ? m_currentAngleDeg + m_angleIncrementDeg : m_currentAngleDeg - m_angleIncrementDeg;
+    ulong currentColor = m_colorPattern->getNextColor();
+
+    for (int row = 0; row < m_pixelBuffer->getRowCount(); row++)
+    {
+        for (int col = 0; col < m_pixelBuffer->getColumnCount(); col++)
+        {
+            // Calculate angle from center to this pixel.
+            float deltaY = row - m_centerRow;
+            float deltaX = col - m_centerColumn;
+            float angleToPixelDeg = std::atan2(deltaY, deltaX) * (180.0f / M_PI);
+            if (angleToPixelDeg < 0.0f)
+            {
+                angleToPixelDeg += 360.0f;
+            }
+
+            if (isAngleInRange(angleToPixelDeg, m_currentAngleDeg, newAngleDeg))
+            {
+                m_pixelBuffer->setColorInPixelMap(row, col, currentColor);
+            }
+        }
+    }
+
+    m_currentAngleDeg = newAngleDeg;
+    if (m_currentAngleDeg >= 360.0f)
+    {
+        m_currentAngleDeg -= 360.0f;
+    }
+    if (m_currentAngleDeg < 0.0f)
+    {
+        m_currentAngleDeg += 360.0f;
+    }
+}
+
+boolean RotationDisplayPattern::isAngleInRange(float angleToCheck, float startAngle, float endAngle)
+{
+    if (startAngle < endAngle)
+    {
+        // angle is increasing
+        if (angleToCheck >= startAngle && angleToCheck < endAngle)
+        {
+            return true;
+        }
+        // Check if we've wrapped around past 360 degrees
+        if (endAngle >= 360.0f)
+        {
+            if (angleToCheck + 360 >= startAngle && angleToCheck + 360 < endAngle)
+            {
+                return true;
+            }
+        }
+    }
+    else
+    {
+        // angle is decreasing
+        if (angleToCheck <= startAngle && angleToCheck > endAngle)
+        {
+            return true;
+        }
+        // Check if we've wrapped around past 0 degrees
+        if (endAngle < 0.0f)
+        {
+            if (angleToCheck - 360 <= startAngle && angleToCheck - 360 > endAngle)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+std::vector<String> RotationDisplayPattern::getParameterNames()
+{
+    std::vector<String> parameterNames;
+
+    parameterNames.push_back("Number of rays");
+    parameterNames.push_back("Angle increment");
+
+    return parameterNames;
+}

--- a/lib/DisplayPatternLib/src/DisplayPatterns/RotationDisplayPattern.h
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/RotationDisplayPattern.h
@@ -1,0 +1,31 @@
+#ifndef ROTATION_DISPLAY_PATTERN_H
+#define ROTATION_DISPLAY_PATTERN_H
+
+#include "DisplayPattern.h"
+
+class RotationDisplayPattern : public DisplayPattern
+{
+    public:
+        RotationDisplayPattern(boolean isClockwise, PixelBuffer *pixels);
+
+        static std::vector<String> getParameterNames();
+
+        void setNumberOfRays(byte unscaledValue);
+        void setAngleIncrementDeg(byte unscaledValue);
+
+    protected:
+        virtual void resetInternal();
+        virtual void updateInternal();
+
+    private:
+        boolean isAngleInRange(float angleToCheck, float startAngle, float endAngle);
+
+        boolean m_isClockwise{true};
+        uint m_numberOfRays{1};
+        int m_angleIncrementDeg{5};
+        float m_centerRow{0.0f};
+        float m_centerColumn{0.0f};
+        float m_currentAngleDeg{0.0f};
+};
+
+#endif

--- a/lib/DisplayPatternLib/src/PatternFactory.cpp
+++ b/lib/DisplayPatternLib/src/PatternFactory.cpp
@@ -115,6 +115,24 @@ DisplayPattern* PatternFactory::createForPatternData(const PatternData& patternD
             displayPattern = pattern;
             break;
         }
+        case DisplayPatternType::Rotation:
+        {
+            RotationDisplayPattern* pattern = new RotationDisplayPattern(true, pixelBuffer);
+            pattern->setColorPattern(colorPattern);
+            pattern->setNumberOfRays(params[startOfDisplayParameters]);
+            pattern->setAngleIncrementDeg(params[startOfDisplayParameters + 1]);
+            displayPattern = pattern;
+            break;
+        }
+        case DisplayPatternType::RotationCCW:
+        {
+            RotationDisplayPattern* pattern = new RotationDisplayPattern(false, pixelBuffer);
+            pattern->setColorPattern(colorPattern);
+            pattern->setNumberOfRays(params[startOfDisplayParameters]);
+            pattern->setAngleIncrementDeg(params[startOfDisplayParameters + 1]);
+            displayPattern = pattern;
+            break;
+        }
         default:
         {
             SolidDisplayPattern* pattern = new SolidDisplayPattern(pixelBuffer);

--- a/lib/DisplayPatternLib/src/PatternFactory.h
+++ b/lib/DisplayPatternLib/src/PatternFactory.h
@@ -9,6 +9,7 @@
 #include "DisplayPatterns\RandomDisplayPattern.h"
 #include "DisplayPatterns\CenterOutDisplayPattern.h"
 #include "DisplayPatterns\LowPowerDisplayPattern.h"
+#include "DisplayPatterns\RotationDisplayPattern.h"
 #include "ColorPatterns\ColorPattern.h"
 #include "ColorPatterns\ColorFadePattern.h"
 #include "ColorPatterns\RainbowColorPattern.h"

--- a/lib/DisplayPatternLib/src/enums/DisplayPatternType.h
+++ b/lib/DisplayPatternLib/src/enums/DisplayPatternType.h
@@ -12,13 +12,15 @@ enum class DisplayPatternType : byte
     Down = 4,
     Digit = 5,
     Random = 6,
-	CenterOutVertical = 7,
-	CenterOutHorizontal = 8,
-	Line = 9,
+    CenterOutVertical = 7,
+    CenterOutHorizontal = 8,
+    Line = 9,
     LowPower = 10,
     Fire = 11,
     Fire2 = 12,
-    Fire3 = 13
+    Fire3 = 13,
+    Rotation = 14,
+    RotationCCW = 15
 };
 
 #endif

--- a/lib/PixelBufferLib/src/PixelBuffer.cpp
+++ b/lib/PixelBufferLib/src/PixelBuffer.cpp
@@ -350,7 +350,6 @@ void PixelBuffer::setColorForMappedPixels(std::vector<int> *destination, uint32_
 
 void PixelBuffer::setColorInPixelMap(uint row, uint column, ulong color)
 {
-    // Since this is private for now, we could remove the guard clauses for better performance.
     if (row >= m_colorMap.size())
     {
         return;

--- a/lib/PixelBufferLib/src/PixelBuffer.h
+++ b/lib/PixelBufferLib/src/PixelBuffer.h
@@ -94,8 +94,11 @@ class PixelBuffer {
 
     uint getDigitCount();
 
-    // Set an individual pixel in the buffer to a color.
+    // Set an individual pixel in the raw pixel buffer to a color.
     void setPixel(uint pixel, ulong color);
+
+    // Set the color of a specific pixel in the row/column map.
+    void setColorInPixelMap(uint row, uint column, ulong color);
 
     // Set all pixels in the given row to the given color.
     void setRowColor(uint row, ulong newColor);
@@ -147,9 +150,6 @@ class PixelBuffer {
     void shiftPixelBlocksRight(std::vector<std::vector<int>*> pixelBlocks, ulong newColor, uint startingBlock);
     void shiftPixelBlocksLeft(std::vector<std::vector<int>*> pixelBlocks, ulong newColor, uint startingBlock);
     
-    // Update the color in the color map and write through to the pixel buffer if a pixel exists at that location.
-    void setColorInPixelMap(uint row, uint column, ulong color);
-
     // Row, then column. Value is the pixel index or -1 if no pixel at that location.
     std::vector<std::vector<int>> m_pixelMap;
     std::vector<std::vector<ulong>> m_colorMap;


### PR DESCRIPTION
Adding a Rotation display pattern.
The pattern can be run clockwise or counterclockwise, and can utilize between 1 and 4 "rays" that sweep across the display.