### PR TITLE
Add framework to enable unit tests in LegacyController

### DIFF
--- a/LegacySignController/platformio.ini
+++ b/LegacySignController/platformio.ini
@@ -17,6 +17,20 @@ lib_deps =
 	https://github.com/avishorp/TM1637#v1.2.0
 	arduino-libraries/ArduinoBLE@^1.3.6
 	adafruit/Adafruit NeoPixel@^1.12.3
+build_src_filter = 
+	+<*>
+	-<.git/>
+	-<desktop/>
 
 [platformio]
 lib_dir = ../lib
+
+[env:desktop]
+; A native environment for desktop testing, using ArduinoFake to mock Arduino functions.
+platform = native
+test_framework = unity
+build_src_filter = 
+	+<desktop/**>
+lib_deps = 
+	ArduinoFake
+	bblanchon/ArduinoJson@^7.3.0

--- a/LegacySignController/src/desktop/main.cpp
+++ b/LegacySignController/src/desktop/main.cpp
@@ -1,0 +1,2 @@
+// Dummy do-nothing main.cpp to allow desktop builds and unit tests.
+int main(int argc, char **argv) {}

--- a/LegacySignController/test/test_SanityCheck/DummyTest.cpp
+++ b/LegacySignController/test/test_SanityCheck/DummyTest.cpp
@@ -1,0 +1,19 @@
+#include <unity.h>
+
+void setUp(void) {
+}
+
+void tearDown(void) {
+}
+
+void sanityTest(void) {
+    TEST_ASSERT_EQUAL(1, 1);
+}
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    RUN_TEST(sanityTest);
+    
+    return UNITY_END();
+}


### PR DESCRIPTION
Add start of testing framework to the LegacySignController workspace.  (The hope is that "Legacy" will be the new home for "Common" eventually.)