### PR TITLE
Add ButtonProcessor framework and tests

### DIFF
--- a/LegacySignController/src/ArduinoPushButton/ArduinoPushButton.cpp
+++ b/LegacySignController/src/ArduinoPushButton/ArduinoPushButton.cpp
@@ -1,0 +1,106 @@
+#include "ArduinoPushButton.h"
+
+ArduinoPushButton::ArduinoPushButton(int pinNumber, PinMode mode)
+{
+    pinMode(pinNumber, mode);
+    m_pinNumber = pinNumber;
+}
+
+bool ArduinoPushButton::wasPressed()
+{
+    bool pressed = m_wasPressed;
+    return pressed;
+}
+
+void ArduinoPushButton::clearPress()
+{
+    m_wasPressed = false;
+    m_lastPressType = ButtonPressType::None;
+}
+
+ButtonPressType ArduinoPushButton::lastPressType()
+{
+    return m_lastPressType;
+}
+
+PinStatus ArduinoPushButton::rawPinStatus()
+{
+    return digitalRead(m_pinNumber);
+}
+
+void ArduinoPushButton::update()
+{
+    if (digitalRead(m_pinNumber) == LOW)
+    {
+        // Button is down.
+        if (!m_isDown)
+        {
+            // Button was up, but is down now.
+            // Check to see if we're outside the debounce window
+            if (millis() > m_lastTransitionTime + PUSHBUTTON_DEBOUNCE_INTERVAL)
+            {
+                m_lastDownTime = millis();
+                m_lastTransitionTime = m_lastDownTime;
+                m_isDown = true;
+            }
+            if (millis() > m_lastUpTime + DOUBLETAP_INTERVAL)
+            {
+                // Outside the double-tap window, so treat this as a new tap series.
+                m_consecutiveCount = 1;
+            }
+            else
+            {
+                // Inside the double-tap window
+                m_consecutiveCount++;
+            }
+        }
+    }
+    else
+    {
+        // Button is up.
+        if (m_isDown)
+        {
+            // Button was down, but is up now.
+            // check to see if we're outside the debounce window
+            if (millis() > m_lastTransitionTime + PUSHBUTTON_DEBOUNCE_INTERVAL)
+            {
+                m_lastUpTime = millis();
+                m_lastTransitionTime = m_lastUpTime;
+                m_isDown = false;
+                m_inDelayInterval = true;
+            }
+        }
+        else
+        {
+            // If we're inside the delay interval, the next press would be treated
+            // as a double-press.  If we've exited the delay interval, count this
+            // as an actual press and stop waiting.
+            if (m_inDelayInterval && (millis() > m_lastUpTime + DOUBLETAP_INTERVAL))
+            {
+                m_inDelayInterval = false;
+                m_wasPressed = true;
+                ulong pressTime = m_lastUpTime - m_lastDownTime;
+                setPressType(pressTime);
+            }
+        }
+    }
+}
+
+void ArduinoPushButton::setPressType(ulong pressTime)
+{
+    if (pressTime > PUSHBUTTON_LONGPRESS)
+    {
+        m_lastPressType = ButtonPressType::Long;
+    }
+    else
+    {
+        if (m_consecutiveCount > 1)
+        {
+            m_lastPressType = ButtonPressType::Double;
+        }
+        else
+        {
+            m_lastPressType = ButtonPressType::Normal;
+        }
+    }
+}

--- a/LegacySignController/src/ArduinoPushButton/ArduinoPushButton.h
+++ b/LegacySignController/src/ArduinoPushButton/ArduinoPushButton.h
@@ -1,0 +1,33 @@
+#ifndef ARDUINO_PUSHBUTTON_H
+#define ARDUINO_PUSHBUTTON_H
+
+#include <Arduino.h>
+#include "../ButtonProcessor/GenericButton.h"
+
+#define PUSHBUTTON_DEBOUNCE_INTERVAL 50
+#define PUSHBUTTON_LONGPRESS 500
+#define DOUBLETAP_INTERVAL 150
+
+class ArduinoPushButton : public GenericButton {
+    public:
+        ArduinoPushButton(int pinNumber, PinMode pinMode);
+        virtual void update();
+        virtual bool wasPressed();
+        virtual ButtonPressType lastPressType();
+        virtual void clearPress();
+        PinStatus rawPinStatus();
+    
+    private:
+        int m_pinNumber{0};
+        bool m_isDown{false};
+        ulong m_lastDownTime{0};
+        ulong m_lastUpTime{0};
+        ulong m_lastTransitionTime{0};
+        bool m_inDelayInterval{false};
+        bool m_wasPressed{false};
+        int m_consecutiveCount{0};
+        ButtonPressType m_lastPressType{ButtonPressType::None};
+        void setPressType(ulong pressTime);
+};
+
+#endif

--- a/LegacySignController/src/ButtonProcessor/ButtonAction.cpp
+++ b/LegacySignController/src/ButtonProcessor/ButtonAction.cpp
@@ -1,0 +1,19 @@
+#include "ButtonAction.h"
+
+int ButtonAction::m_nextId = 0;
+
+ButtonAction::ButtonAction(std::vector<String> buttonNames, String actionName, std::vector<String> arguments)
+{
+    m_actionName = actionName;
+    m_id = m_nextId++;
+
+    for (String buttonName : buttonNames)
+    {
+        m_buttonNames.push_back(buttonName);
+    }
+
+    for (String argument : arguments)
+    {
+        m_arguments.push_back(argument);
+    }
+}

--- a/LegacySignController/src/ButtonProcessor/ButtonAction.h
+++ b/LegacySignController/src/ButtonProcessor/ButtonAction.h
@@ -1,0 +1,26 @@
+#ifndef BUTTON_ACTION_H
+#define BUTTON_ACTION_H
+
+#include <Arduino.h>
+#include <vector>
+
+class ButtonAction
+{
+    public:
+        ButtonAction(std::vector<String> buttonNames, String actionName, std::vector<String> arguments = std::vector<String>());
+
+        int getId() { return m_id; }
+        std::vector<String>& getButtonNames() { return m_buttonNames; }
+        String getActionName() { return m_actionName; }
+        std::vector<String>& getArguments() { return m_arguments; }
+
+    private:
+        ButtonAction() {}
+        static int m_nextId;
+        int m_id;
+        std::vector<String> m_buttonNames;
+        String m_actionName;
+        std::vector<String> m_arguments;
+};
+
+#endif

--- a/LegacySignController/src/ButtonProcessor/ButtonProcessor.cpp
+++ b/LegacySignController/src/ButtonProcessor/ButtonProcessor.cpp
@@ -1,0 +1,120 @@
+#include "ButtonProcessor.h"
+
+ButtonProcessor::ButtonProcessor()
+{
+}
+
+void ButtonProcessor::addButtonDefinition(String buttonName, GenericButton* button)
+{
+    if (m_buttonMap.find(buttonName) != m_buttonMap.end())
+    {
+        // button already exists
+        ("Button with name '");
+        DebugUtils::print(buttonName.c_str());
+        DebugUtils::println("' already exists");
+        return;
+    }
+
+    m_buttonMap[buttonName] = button;
+}
+
+void ButtonProcessor::addTapAction(std::vector<String> buttonNames, String actionName, std::vector<String> arguments)
+{
+    addAction(buttonNames, actionName, arguments, m_tapActions);
+}
+
+void ButtonProcessor::addLongTapAction(std::vector<String> buttonNames, String actionName, std::vector<String> arguments)
+{
+    addAction(buttonNames, actionName, arguments, m_longTapActions);
+}
+
+void ButtonProcessor::addAction(
+    std::vector<String>& buttonNames, 
+    String& actionName, 
+    std::vector<String>& arguments, 
+    std::vector<ButtonAction*>& actionList)
+{
+    if (buttonNames.size() == 0)
+    {
+        DebugUtils::println("No buttons specified for tap action");
+        return;
+    }
+
+    for (String buttonName : buttonNames)
+    {
+        if (m_buttonMap.find(buttonName) == m_buttonMap.end())
+        {
+            // button by that name doesn't exist.  Ignore the action.
+            return;
+        }
+    }
+
+    ButtonAction* action = new ButtonAction(buttonNames, actionName, arguments);
+    actionList.push_back(action);
+
+    // Keep them sorted by the number of buttons in the combination
+    std::sort(
+        actionList.begin(),
+        actionList.end(),
+        [](ButtonAction* &a, ButtonAction* &b)
+            { return a->getButtonNames().size() > b->getButtonNames().size(); });
+}
+
+std::vector<GenericButton*> ButtonProcessor::getButtons() {
+    std::vector<GenericButton*> buttons;
+
+    for (auto const& mapEntry : m_buttonMap) {
+        buttons.push_back(mapEntry.second);
+    }
+
+    return buttons;
+}
+
+void ButtonProcessor::update() {
+    // Update all the buttons
+    for (auto const& mapEntry : m_buttonMap) {
+        mapEntry.second->update();
+    }
+
+    bool actionProcessed = lookForAndExecuteAction(m_longTapActions, ButtonPressType::Long);
+
+    if (!actionProcessed)
+    {
+        // No long tap actions were processed, so look for normal tap actions.
+        actionProcessed = lookForAndExecuteAction(m_tapActions, ButtonPressType::Normal);
+    }
+
+    // If an action was run, reset all the buttons
+    if (actionProcessed)
+    {
+        for (auto const& mapEntry : m_buttonMap) {
+            mapEntry.second->clearPress();
+        }
+    }
+}
+
+bool ButtonProcessor::lookForAndExecuteAction(std::vector<ButtonAction*>& actionsToProcess, ButtonPressType pressType)
+{
+    for (ButtonAction* buttonAction : actionsToProcess) {
+        bool allPressed = true;
+
+        for (String buttonName : buttonAction->getButtonNames()) {
+            if (!m_buttonMap[buttonName]->wasPressed() || m_buttonMap[buttonName]->lastPressType() != pressType) 
+            {
+                allPressed = false;
+            }
+        }
+
+        if (allPressed)
+        {
+            if (m_actionProcessor)
+            {
+                m_actionProcessor(buttonAction->getId(), buttonAction->getActionName(), buttonAction->getArguments());
+            }
+            
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/LegacySignController/src/ButtonProcessor/ButtonProcessor.h
+++ b/LegacySignController/src/ButtonProcessor/ButtonProcessor.h
@@ -1,0 +1,43 @@
+#ifndef BUTTON_PROCESSOR_H
+#define BUTTON_PROCESSOR_H
+
+#include <Arduino.h>
+#include <vector>
+#include <map>
+#include <algorithm>
+#include "GenericButton.h"
+#include "ButtonAction.h"
+#include "Utils\DebugUtils.h"
+
+typedef void (*ButtonActionProcessor)(int callerId, String actionName, std::vector<String> arguments);
+
+class ButtonProcessor
+{
+    public:
+        ButtonProcessor();
+        void addButtonDefinition(String buttonName, GenericButton* button);
+
+        void addTapAction(std::vector<String> buttonNames, String actionName, std::vector<String> arguments = std::vector<String>());
+        void addLongTapAction(std::vector<String> buttonNames, String actionName, std::vector<String> arguments = std::vector<String>());
+
+        void setActionProcessor(ButtonActionProcessor actionProcessor) { m_actionProcessor = actionProcessor; }
+        
+        void update();
+
+        std::vector<GenericButton*> getButtons();
+
+    private:
+        ButtonActionProcessor m_actionProcessor{nullptr};
+        std::map<String, GenericButton*> m_buttonMap;
+        std::vector<ButtonAction*> m_tapActions;
+        std::vector<ButtonAction*> m_longTapActions;
+
+        bool lookForAndExecuteAction(std::vector<ButtonAction*>& actionsToProcess, ButtonPressType pressType);
+        void addAction(
+            std::vector<String>& buttonNames, 
+            String& actionName, 
+            std::vector<String>& arguments, 
+            std::vector<ButtonAction*>& actionList);
+};
+
+#endif

--- a/LegacySignController/src/ButtonProcessor/GenericButton.h
+++ b/LegacySignController/src/ButtonProcessor/GenericButton.h
@@ -1,0 +1,19 @@
+#ifndef GENERIC_BUTTON_H
+#define GENERIC_BUTTON_H
+
+enum class ButtonPressType {
+    None,
+    Normal,
+    Long,
+    Double
+};
+
+class GenericButton {
+    public:
+        virtual void update() = 0;
+        virtual bool wasPressed() = 0;
+        virtual ButtonPressType lastPressType() = 0;
+        virtual void clearPress() = 0;;
+};
+
+#endif

--- a/LegacySignController/src/Utils/DebugUtils.cpp
+++ b/LegacySignController/src/Utils/DebugUtils.cpp
@@ -1,0 +1,19 @@
+#include "DebugUtils.h"
+
+void DebugUtils::print(const char* message)
+{
+#ifdef PIO_UNIT_TESTING
+    printf("%s", message);
+#else
+    Serial.print(message);
+#endif      
+}
+
+void DebugUtils::println(const char* message)
+{
+#ifdef PIO_UNIT_TESTING
+    printf("%s\n", message);
+#else
+    Serial.println(message);
+#endif      
+}

--- a/LegacySignController/src/Utils/DebugUtils.h
+++ b/LegacySignController/src/Utils/DebugUtils.h
@@ -1,0 +1,19 @@
+#ifndef DEBUGUTILS_H
+#define DEBUGUTILS_H
+
+#include <Arduino.h>
+
+// This class is used to provide debug output.
+// Unit tests can't use the 'Serial' object, so this
+// class emits debug output to the console when running
+// unit tests.
+class DebugUtils
+{
+    public:
+        static void print(const char* message);
+        static void print(String message) { print(message.c_str()); }
+        static void println(const char* message);
+        static void println(String message) { println(message.c_str()); }
+};
+
+#endif

--- a/LegacySignController/src/main.cpp
+++ b/LegacySignController/src/main.cpp
@@ -6,7 +6,7 @@ StatusDisplay display(TM1637_CLOCK, TM1637_DIO, TM1637_BRIGHTNESS);
 PixelBuffer* pixelBuffer;
 DisplayPattern* currentLightStyle;
 
-std::vector<PushButton *> manualInputButtons;
+std::vector<GenericButton *> manualInputButtons;
 PredefinedStyleList* predefinedStyleList;
 ulong loopCounter = 0;
 ulong lastTelemetryTimestamp = 0;
@@ -40,7 +40,7 @@ void setup()
     std::vector<int> manualInputPins{MANUAL_INPUT_PINS};
     for (uint i = 0; i < manualInputPins.size(); i++)
     {
-        manualInputButtons.push_back(new PushButton(manualInputPins[i], INPUT_PULLUP));
+        manualInputButtons.push_back(new ArduinoPushButton(manualInputPins[i], INPUT_PULLUP));
     }
 
     initializeIO();

--- a/LegacySignController/src/main.h
+++ b/LegacySignController/src/main.h
@@ -4,10 +4,11 @@
 #include <algorithm>
 #include <BluetoothCommon.h>
 #include <DisplayPatternLib.h>
-#include <PushButton.h>
+//#include <PushButton.h>
 #include <StatusDisplay.h>
 #include <PredefinedStyleLib.h>
 #include <PixelBufferLib.h>
+#include "ArduinoPushButton/ArduinoPushButton.h"
 
 #define DATA_OUT 25            // GPIO pin # (NOT Digital pin #) controlling the NeoPixels
 #define VOLTAGEINPUTPIN 29     // GPIO pin # for the analog input to detect battery voltage level.

--- a/LegacySignController/src/main.h
+++ b/LegacySignController/src/main.h
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <BluetoothCommon.h>
 #include <DisplayPatternLib.h>
-//#include <PushButton.h>
 #include <StatusDisplay.h>
 #include <PredefinedStyleLib.h>
 #include <PixelBufferLib.h>

--- a/LegacySignController/test/TestHelpers/MockButton.cpp
+++ b/LegacySignController/test/TestHelpers/MockButton.cpp
@@ -1,0 +1,5 @@
+#include "MockButton.h"
+
+MockButton::MockButton()
+{
+}

--- a/LegacySignController/test/TestHelpers/MockButton.h
+++ b/LegacySignController/test/TestHelpers/MockButton.h
@@ -1,0 +1,24 @@
+#ifndef MOCK_BUTTON_H
+#define MOCK_BUTTON_H
+
+#include "..\src\ButtonProcessor\GenericButton.h"
+
+class MockButton : public GenericButton
+{
+    public:
+        MockButton();
+        virtual void update() { m_wasUpdateCalled = true; }
+        virtual bool wasPressed() { return m_lastPressType != ButtonPressType::None; }
+        virtual ButtonPressType lastPressType() { return m_lastPressType; }
+        virtual void clearPress() { m_lastPressType = ButtonPressType::None; }
+
+        void resetMock() {m_wasUpdateCalled = false; m_lastPressType = ButtonPressType::None; }
+        void setPressType(ButtonPressType pressType) { m_lastPressType = pressType; }
+        bool wasUpdateCalled() { return m_wasUpdateCalled; }
+    
+    private:
+        ButtonPressType m_lastPressType{ButtonPressType::None};
+        bool m_wasUpdateCalled{false};
+};
+
+#endif

--- a/LegacySignController/test/test_ButtonProcessor/ButtonProcessorTests.cpp
+++ b/LegacySignController/test/test_ButtonProcessor/ButtonProcessorTests.cpp
@@ -1,0 +1,246 @@
+#include <Arduino.h>
+#include <unity.h>
+#include <vector>
+
+// Reference any needed cpp files directly to avoid pulling in
+// references that can't be resolved with the "fake" Arduino environment.
+#include "../src/ButtonProcessor/ButtonProcessor.cpp"
+#include "../src/ButtonProcessor/ButtonAction.cpp"
+#include "../src/Utils/DebugUtils.cpp"
+#include "../TestHelpers/MockButton.cpp"
+
+int lastCallerId(-1);
+String lastActionName("");
+std::vector<String> lastArguments;
+
+void resetActionParameters() {
+    lastCallerId = -1;
+    lastActionName = "";
+    lastArguments.clear();
+}
+
+void setUp(void) {
+}
+
+void tearDown(void) {
+}
+
+void processAction(int callerId, String actionName, std::vector<String> arguments) {
+    lastCallerId = callerId;
+    lastActionName = actionName;
+    lastArguments = arguments;
+}
+
+void noButtonsDoNothing() {
+    ButtonProcessor bp;
+    bp.update();
+    TEST_ASSERT_TRUE(true);
+}
+
+void buttonsWithNoActions() {
+    ButtonProcessor bp;
+    MockButton* button1 = new MockButton();
+    MockButton* button2 = new MockButton();
+    bp.addButtonDefinition("Button1", button1);
+    bp.addButtonDefinition("Button2", button2);
+    bp.update();
+    TEST_ASSERT_TRUE_MESSAGE(button1->wasUpdateCalled(), "Button 1 should have been updated.");
+    TEST_ASSERT_TRUE_MESSAGE(button2->wasUpdateCalled(), "Button 2 should have been updated.");
+    button1->setPressType(ButtonPressType::Normal);
+    button2->setPressType(ButtonPressType::Long);
+    bp.update();
+    // No action was done, so the buttons shouldn't have been reset.
+    TEST_ASSERT_EQUAL_MESSAGE(ButtonPressType::Normal, button1->lastPressType(), "Button 1 should have been reset.");
+    TEST_ASSERT_EQUAL_MESSAGE(ButtonPressType::Long, button2->lastPressType(), "Button 2 should have been reset.");
+}
+
+void undefinedActionProcessorDoesNothing() {
+    ButtonProcessor bp;
+    MockButton* button = new MockButton();
+    bp.addButtonDefinition("Button1", button);
+    bp.addTapAction({"Button1"}, "Action1");
+    bp.addLongTapAction({"Button1"}, "Action2");
+    button->setPressType(ButtonPressType::Normal);
+    bp.update();
+    TEST_ASSERT_TRUE(button->wasUpdateCalled());
+    TEST_ASSERT_EQUAL_MESSAGE(ButtonPressType::None, button->lastPressType(), "Button should have been reset after tap.");
+    button->setPressType(ButtonPressType::Long);
+    bp.update();
+    TEST_ASSERT_TRUE(button->wasUpdateCalled());
+    TEST_ASSERT_EQUAL_MESSAGE(ButtonPressType::None, button->lastPressType(), "Button should have been reset after long tap.");
+}
+
+void simpleActionsWithProcessor() {
+    resetActionParameters();
+    ButtonProcessor bp;
+    bp.setActionProcessor(processAction);
+    MockButton* button1 = new MockButton();
+    MockButton* button2 = new MockButton();
+    bp.addButtonDefinition("Button1", button1);
+    bp.addButtonDefinition("Button2", button2);
+    bp.addTapAction({"Button1"}, "Action1");
+    bp.addTapAction({"Button2"}, "Action2", {"arg1", "arg2"});
+    bp.addLongTapAction({"Button1"}, "Action3");
+    
+    button1->setPressType(ButtonPressType::Normal);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action1", lastActionName.c_str(), "Button1's action was not correct.");
+    TEST_ASSERT_EQUAL_MESSAGE(0, lastArguments.size(), "Expected no arguments for the first action.");
+    TEST_ASSERT_EQUAL_MESSAGE(ButtonPressType::None, button1->lastPressType(), "Button1 should have been reset.");
+
+    resetActionParameters();
+    button2->setPressType(ButtonPressType::Normal);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action2", lastActionName.c_str(), "Button2's action was not correct.");
+    TEST_ASSERT_EQUAL_MESSAGE(2, lastArguments.size(), "Expected 2 arguments for the second action.");
+    TEST_ASSERT_EQUAL_MESSAGE(ButtonPressType::None, button2->lastPressType(), "Button2 should have been reset.");
+
+    resetActionParameters();
+    button1->setPressType(ButtonPressType::Long);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action3", lastActionName.c_str(), "Button1's long tap action was not correct.");
+    TEST_ASSERT_EQUAL_MESSAGE(0, lastArguments.size(), "Expected no arguments for the long tap action.");
+    TEST_ASSERT_EQUAL_MESSAGE(ButtonPressType::None, button1->lastPressType(), "Button1 should have been reset after long tap.");
+}
+
+void buttonsClearAfterAction() {
+    resetActionParameters();
+    ButtonProcessor bp;
+    bp.setActionProcessor(processAction);
+    MockButton* button1 = new MockButton();
+    MockButton* button2 = new MockButton();
+    bp.addButtonDefinition("Button1", button1);
+    bp.addButtonDefinition("Button2", button2);
+    bp.addTapAction({"Button1"}, "Action1");
+    button1->setPressType(ButtonPressType::Normal);
+    button2->setPressType(ButtonPressType::Normal);
+    bp.update();
+    // Both buttons should have been reset after the action.
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action1", lastActionName.c_str(), "Button action was not correct.");
+    TEST_ASSERT_EQUAL_MESSAGE(ButtonPressType::None, button1->lastPressType(), "Button1 should have been reset after long tap.");
+    TEST_ASSERT_EQUAL_MESSAGE(ButtonPressType::None, button2->lastPressType(), "Button2 should have been reset after long tap.");
+}
+
+void duplicateButtonsAreIgnored() {
+    resetActionParameters();
+    ButtonProcessor bp;
+    bp.setActionProcessor(processAction);
+    MockButton* button1 = new MockButton();
+    MockButton* button2 = new MockButton();
+    bp.addButtonDefinition("Button", button1);
+    // Button 2 should be ignored.
+    bp.addButtonDefinition("Button", button2);
+    bp.addTapAction({"Button"}, "Action1");
+    button2->setPressType(ButtonPressType::Normal);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("", lastActionName.c_str(), "No action should have been run.");
+}
+
+void combinationActionTests() {
+    resetActionParameters();
+    ButtonProcessor bp;
+    bp.setActionProcessor(processAction);
+    MockButton* button1 = new MockButton();
+    MockButton* button2 = new MockButton();
+    MockButton* button3 = new MockButton();
+    bp.addButtonDefinition("Button1", button1);
+    bp.addButtonDefinition("Button2", button2);
+    bp.addButtonDefinition("Button3", button3);
+    bp.addTapAction({"Button1", "Button2"}, "Action1-2");
+    bp.addTapAction({"Button2"}, "Action2"); // This action shouldn't be called
+    bp.addTapAction({"Button1", "Button2", "Button3"}, "Action1-2-3");
+    button1->setPressType(ButtonPressType::Normal);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("", lastActionName.c_str(), "No action should have been run.");
+    button2->setPressType(ButtonPressType::Normal);
+    button3->setPressType(ButtonPressType::Normal);
+    bp.update();
+    // Largest combination should have been run.
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action1-2-3", lastActionName.c_str(), "Button1/2/3 action was not correct.");
+    button1->setPressType(ButtonPressType::Normal);
+    button2->setPressType(ButtonPressType::Normal);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action1-2", lastActionName.c_str(), "Button1/2 action was not correct.");
+}
+
+void unknownButtonNamesInActionsAreIgnored() {
+    resetActionParameters();
+    ButtonProcessor bp;
+    bp.setActionProcessor(processAction);
+    MockButton* button1 = new MockButton();
+    MockButton* button2 = new MockButton();
+    bp.addButtonDefinition("Button1", button1);
+    bp.addButtonDefinition("Button2", button2);
+    bp.addTapAction({"ButtonX", "Button1"}, "Action1");
+    bp.addTapAction({"ButtonY"}, "Action2");
+    button1->setPressType(ButtonPressType::Normal);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("", lastActionName.c_str(), "No action should have been done.");
+}
+
+void validateActionArguments() {
+    resetActionParameters();
+    ButtonProcessor bp;
+    bp.setActionProcessor(processAction);
+    MockButton* button1 = new MockButton();
+    MockButton* button2 = new MockButton();
+    MockButton* button3 = new MockButton();
+    bp.addButtonDefinition("Button1", button1);
+    bp.addButtonDefinition("Button2", button2);
+    bp.addButtonDefinition("Button3", button2);
+    bp.addTapAction({"Button1"}, "Action1", {"arg1"});
+    bp.addTapAction({"Button2"}, "Action2", {"argx", "argy"});
+    bp.addTapAction({"Button3"}, "Action3", {"arga", "argb", "argc"});
+    bp.addLongTapAction({"Button1"}, "Action4");
+    bp.addLongTapAction({"Button2"}, "Action5", {"foo"});
+    button1->setPressType(ButtonPressType::Normal);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action1", lastActionName.c_str(), "Action1 should have been done.");
+    TEST_ASSERT_EQUAL_MESSAGE(1, lastArguments.size(), "Action1 should have 1 argument.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("arg1", lastArguments.at(0).c_str(), "Action1's argument is not correct.");
+
+    resetActionParameters();
+    button2->setPressType(ButtonPressType::Normal);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action2", lastActionName.c_str(), "Action2 should have been done.");
+    TEST_ASSERT_EQUAL_MESSAGE(2, lastArguments.size(), "Action2 should have 2 arguments.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("argx", lastArguments.at(0).c_str(), "Action2's first argument is not correct.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("argy", lastArguments.at(0).c_str(), "Action2's second argument is not correct.");
+
+    resetActionParameters();
+    button3->setPressType(ButtonPressType::Normal);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action3", lastActionName.c_str(), "Action3 should have been done.");
+    TEST_ASSERT_EQUAL_MESSAGE(3, lastArguments.size(), "Action3 should have 3 arguments.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("arga", lastArguments.at(0).c_str(), "Action3's first argument is not correct.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("argb", lastArguments.at(0).c_str(), "Action3's second argument is not correct.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("argc", lastArguments.at(0).c_str(), "Action3's third argument is not correct.");
+
+    resetActionParameters();
+    button1->setPressType(ButtonPressType::Long);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action4", lastActionName.c_str(), "Action4 should have been done.");
+    TEST_ASSERT_EQUAL_MESSAGE(0, lastArguments.size(), "Action4 should have no arguments.");
+
+    resetActionParameters();
+    button2->setPressType(ButtonPressType::Long);
+    bp.update();
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Action5", lastActionName.c_str(), "Action5 should have been done.");
+    TEST_ASSERT_EQUAL_MESSAGE(1, lastArguments.size(), "Action5 should have 1 argument.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("foo", lastArguments.at(0).c_str(), "Action5's argument is not correct.");
+}
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    RUN_TEST(noButtonsDoNothing);
+    RUN_TEST(buttonsWithNoActions);
+    RUN_TEST(undefinedActionProcessorDoesNothing);
+    RUN_TEST(simpleActionsWithProcessor);
+    RUN_TEST(buttonsClearAfterAction);
+    RUN_TEST(duplicateButtonsAreIgnored);
+    RUN_TEST(combinationActionTests);
+    RUN_TEST(unknownButtonNamesInActionsAreIgnored);
+    
+    return UNITY_END();
+}


### PR DESCRIPTION
Adding the `ButtonProcessor` and associated classes and tests from the older "Refactor" branch.
The LegacySignController has been updated to use the new `ArduinoPushButton` class, but the `ButtonProcessor` itself is not yet utilized.