### PR TITLE
Streamline PixelMap functions

### DIFF
--- a/LegacySignController/src/NeoPixelDisplay.cpp
+++ b/LegacySignController/src/NeoPixelDisplay.cpp
@@ -95,9 +95,11 @@ void NeoPixelDisplay::setSpeed(byte speed)
 
 void NeoPixelDisplay::outputPixels()
 {
+    // No locking here:
+    // This is an internal method and we should have already taken a lock.
     for (uint i = 0; i < m_pixelMap->getPixelCount(); i++)
     {
-        m_neoPixels->setPixelColor(i, m_pixelMap->getPixel(i));
+        m_neoPixels->setPixelColor(i, m_pixelMap->getRawPixelColor(i));
     }
 
     unsigned long start = millis();

--- a/lib/DisplayPatternLib/src/DisplayPatterns/CenterOutDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/CenterOutDisplayPattern.cpp
@@ -79,12 +79,14 @@ void CenterOutDisplayPattern::updateInternal(PixelMap* pixelMap)
         if (m_centerLine > pixelMap->getColsToLeft() + pixelMap->getColumnCount())
         {
             // Center line is to the right of this display, so we'll only be shifting left.
-            pixelMap->shiftColumnsLeft(newColor);
+            pixelMap->shiftColumnsLeft();
+            pixelMap->setColumnColor(pixelMap->getColumnCount() - 1, newColor);
         }
         else if (m_centerLine < pixelMap->getColsToLeft())
         {
             // Center line is to the left of this display, so we'll only be shifting right.
-            pixelMap->shiftColumnsRight(newColor);
+            pixelMap->shiftColumnsRight();
+            pixelMap->setColumnColor(0, newColor);
         }
         else
         {

--- a/lib/DisplayPatternLib/src/DisplayPatterns/CenterOutDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/CenterOutDisplayPattern.cpp
@@ -71,8 +71,10 @@ void CenterOutDisplayPattern::updateInternal(PixelMap* pixelMap)
 
     if (m_orientation == CenterOutOrientation::Vertical)
     {
-        pixelMap->shiftRowsUp(newColor, m_centerLine);
-        pixelMap->shiftRowsDown(newColor, m_centerLine + 1);
+        pixelMap->shiftRowsUp(m_centerLine);
+        pixelMap->setRowColor(m_centerLine, newColor);
+        pixelMap->shiftRowsDown(m_centerLine + 1);
+        pixelMap->setRowColor(m_centerLine + 1, newColor);
     }
     else
     {
@@ -91,9 +93,11 @@ void CenterOutDisplayPattern::updateInternal(PixelMap* pixelMap)
         else
         {
             uint16_t localCenter = m_centerLine - pixelMap->getColsToLeft();
-            pixelMap->shiftColumnsLeft(newColor, localCenter);
+            pixelMap->shiftColumnsLeft(localCenter);
+            pixelMap->setColumnColor(localCenter, newColor);
             if (localCenter < pixelMap->getColumnCount() - 1) {
-                pixelMap->shiftColumnsRight(newColor, localCenter + 1);
+                pixelMap->shiftColumnsRight(localCenter + 1);
+                pixelMap->setColumnColor(localCenter + 1, newColor);
             }
         }
     }

--- a/lib/DisplayPatternLib/src/DisplayPatterns/FireDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/FireDisplayPattern.cpp
@@ -62,7 +62,7 @@ void FireDisplayPattern::updateInternal(PixelMap* pixelMap)
             uint32_t color = m_heatColors[temperature];
             for (int pixel : m_combinedRowGroups[group][numRows - row - 1])
             {
-                pixelMap->setRawPixel(pixel, color);
+                pixelMap->setRawPixelColor(pixel, color);
             }
         }
     }

--- a/lib/DisplayPatternLib/src/DisplayPatterns/FireDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/FireDisplayPattern.cpp
@@ -62,7 +62,7 @@ void FireDisplayPattern::updateInternal(PixelMap* pixelMap)
             uint32_t color = m_heatColors[temperature];
             for (int pixel : m_combinedRowGroups[group][numRows - row - 1])
             {
-                pixelMap->setPixel(pixel, color);
+                pixelMap->setRawPixel(pixel, color);
             }
         }
     }

--- a/lib/DisplayPatternLib/src/DisplayPatterns/LowPowerDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/LowPowerDisplayPattern.cpp
@@ -21,11 +21,11 @@ void LowPowerDisplayPattern::updateInternal(PixelMap* pixelMap)
     // to the "next color" from the pattern (which should normally be just a solid color).
     if (m_iterationCount % 2 == 0)
     {
-        pixelMap->setRawPixel(0, m_colorPattern->getNextColor());
+        pixelMap->setRawPixelColor(0, m_colorPattern->getNextColor());
     }
     else
     {
-        pixelMap->setRawPixel(0, 0);
+        pixelMap->setRawPixelColor(0, 0);
     }
     
     m_iterationCount++;    

--- a/lib/DisplayPatternLib/src/DisplayPatterns/LowPowerDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/LowPowerDisplayPattern.cpp
@@ -21,11 +21,11 @@ void LowPowerDisplayPattern::updateInternal(PixelMap* pixelMap)
     // to the "next color" from the pattern (which should normally be just a solid color).
     if (m_iterationCount % 2 == 0)
     {
-        pixelMap->setPixel(0, m_colorPattern->getNextColor());
+        pixelMap->setRawPixel(0, m_colorPattern->getNextColor());
     }
     else
     {
-        pixelMap->setPixel(0, 0);
+        pixelMap->setRawPixel(0, 0);
     }
     
     m_iterationCount++;    

--- a/lib/DisplayPatternLib/src/DisplayPatterns/SimpleShiftDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/SimpleShiftDisplayPattern.cpp
@@ -24,22 +24,28 @@ void SimpleShiftDisplayPattern::updateInternal(PixelMap* pixelMap)
     switch (m_shiftType)
     {
         case ShiftType::Right:
-            pixelMap->shiftColumnsRight(newColor);
+            pixelMap->shiftColumnsRight();
+            pixelMap->setColumnColor(0, newColor);
             return;
         case ShiftType::Left:
-            pixelMap->shiftColumnsLeft(newColor);
+            pixelMap->shiftColumnsLeft();
+            pixelMap->setColumnColor(pixelMap->getColumnCount() - 1, newColor);
             return;
         case ShiftType::Up:
-            pixelMap->shiftRowsUp(newColor);
+            pixelMap->shiftRowsUp();
+            pixelMap->setRowColor(pixelMap->getRowCount() - 1, newColor);
             return;
         case ShiftType::Down:
-            pixelMap->shiftRowsDown(newColor);
+            pixelMap->shiftRowsDown();
+            pixelMap->setRowColor(0, newColor);
             return;
         case ShiftType::Digit:
-            pixelMap->shiftDigitsRight(newColor);
+            pixelMap->shiftDigitsRight();
+            pixelMap->setDigitColor(0, newColor);
             return;
         case ShiftType::Line:
-            pixelMap->shiftPixelsRight(newColor);
+            pixelMap->shiftPixelsRight();
+            pixelMap->setRawPixel(0, newColor);
             return;
         default:
             // Default to Solid (ie, all lights the same color)

--- a/lib/DisplayPatternLib/src/DisplayPatterns/SimpleShiftDisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPatterns/SimpleShiftDisplayPattern.cpp
@@ -45,7 +45,7 @@ void SimpleShiftDisplayPattern::updateInternal(PixelMap* pixelMap)
             return;
         case ShiftType::Line:
             pixelMap->shiftPixelsRight();
-            pixelMap->setRawPixel(0, newColor);
+            pixelMap->setRawPixelColor(0, newColor);
             return;
         default:
             // Default to Solid (ie, all lights the same color)

--- a/lib/PixelMap/PixelMap.cpp
+++ b/lib/PixelMap/PixelMap.cpp
@@ -239,17 +239,6 @@ void PixelMap::fillRandomly(uint32_t newColor, uint16_t numberOfPixels)
     }
 }
 
-void PixelMap::shiftPixelsRight(uint32_t newColor)
-{
-    // Use signed int to avoid underflow when decrementing from 0
-    for (int i = m_numPixels - 1; i >= 1; i--)
-    {
-        m_pixelColors[i] = m_pixelColors[i - 1];
-    }
-
-    m_pixelColors[0] = newColor;
-}
-
 void PixelMap::shiftPixelsRight()
 {
     // Use signed int to avoid underflow when decrementing from 0
@@ -257,16 +246,6 @@ void PixelMap::shiftPixelsRight()
     {
         m_pixelColors[i] = m_pixelColors[i - 1];
     }
-}
-
-void PixelMap::shiftPixelsLeft(uint32_t newColor)
-{
-    for (uint16_t i = 0; i < m_numPixels - 1; i++)
-    {
-        m_pixelColors[i] = m_pixelColors[i + 1];
-    }
-
-    m_pixelColors[m_numPixels - 1] = newColor;
 }
 
 void PixelMap::shiftPixelsLeft()
@@ -290,23 +269,6 @@ void PixelMap::shiftColumnsRight()
     }
 }
 
-void PixelMap::shiftColumnsRight(uint32_t newColor)
-{
-    if (m_columns.size() == 0) return;  // Safety check
-    
-    // Shift all columns to the right, then fill the first column with the new color.
-    for (uint16_t row = 0; row < m_rows.size(); row++)
-    {
-        // Use signed int to prevent underflow
-        for (int col = m_columns.size() - 1; col > 0; col--)
-        {
-            setColorInPixelMap(row, col, m_colorMap[row][col-1]);
-        }
-
-        setColorInPixelMap(row, 0, newColor);
-    }
-}
-
 // Update to use the new pixel map.
 // Currently only used by the CenterOut pattern.
 void PixelMap::shiftColumnsRight(uint32_t newColor, uint16_t startingColumn)
@@ -325,39 +287,11 @@ void PixelMap::shiftColumnsLeft()
     }
 }
 
-void PixelMap::shiftColumnsLeft(uint32_t newColor)
-{
-    // Shift all columns to the left, then fill the last column with the new color.
-    for (uint16_t row = 0; row < m_rows.size(); row++)
-    {
-        for (uint16_t col = 0; col < m_columns.size() - 1; col++)
-        {
-            setColorInPixelMap(row, col, m_colorMap[row][col+1]);
-        }
-
-        setColorInPixelMap(row, m_columns.size() - 1, newColor);
-    }
-}
-
 // Update to use the new pixel map.
 // Currently only used by the CenterOut pattern.
 void PixelMap::shiftColumnsLeft(uint32_t newColor, uint16_t startingColumn)
 {
     shiftPixelBlocksLeft(m_columns, newColor, startingColumn);
-}
-
-void PixelMap::shiftRowsUp(uint32_t newColor)
-{
-    // Shift all rows up, then fill the last row with the new color.
-    for (uint16_t col = 0; col < m_columns.size(); col++)
-    {
-        for (uint16_t row = 0; row < m_rows.size() - 1; row++)
-        {
-            setColorInPixelMap(row, col, m_colorMap[row+1][col]);
-        }
-
-        setColorInPixelMap(m_rows.size() - 1, col, newColor);
-    }
 }
 
 void PixelMap::shiftRowsUp()
@@ -378,23 +312,6 @@ void PixelMap::shiftRowsUp(uint32_t newColor, uint16_t startingRow)
     shiftPixelBlocksLeft(m_rows, newColor, startingRow);
 }
 
-void PixelMap::shiftRowsDown(uint32_t newColor)
-{
-    if (m_rows.size() == 0) return;  // Safety check
-    
-    // Shift all rows down, then fill the first row with the new color.
-    for (uint16_t col = 0; col < m_columns.size(); col++)
-    {
-        // Use signed int to prevent underflow
-        for (int row = m_rows.size() - 1; row > 0; row--)
-        {
-            setColorInPixelMap(row, col, m_colorMap[row-1][col]);
-        }
-
-        setColorInPixelMap(0, col, newColor);
-    }
-}
-
 void PixelMap::shiftRowsDown()
 {
     if (m_rows.size() == 0) return;  // Safety check
@@ -413,13 +330,6 @@ void PixelMap::shiftRowsDown()
 void PixelMap::shiftRowsDown(uint32_t newColor, uint16_t startingRow)
 {
     shiftPixelBlocksRight(m_rows, newColor, startingRow);
-}
-
-// Update to use the new pixel map.
-// Currently only used by the CenterOut pattern.
-void PixelMap::shiftDigitsRight(uint32_t newColor)
-{
-    shiftPixelBlocksRight(m_digits, newColor, 0);
 }
 
 void PixelMap::shiftDigitsRight()

--- a/lib/PixelMap/PixelMap.cpp
+++ b/lib/PixelMap/PixelMap.cpp
@@ -172,7 +172,7 @@ uint16_t PixelMap::getPixelCount()
     return m_numPixels;
 }
 
-void PixelMap::setRawPixel(uint16_t pixel, uint32_t color)
+void PixelMap::setRawPixelColor(uint16_t pixel, uint32_t color)
 {
     if (pixel >= m_numPixels)
     {
@@ -218,7 +218,7 @@ void PixelMap::setDigitColor(uint16_t digit, uint32_t newColor)
     std::vector<int>* digitPixels = m_digits.at(digit);
     for (int pixelIndex : *digitPixels)
     {
-        setRawPixel(pixelIndex, newColor);
+        setRawPixelColor(pixelIndex, newColor);
     }
 }
 
@@ -241,7 +241,6 @@ void PixelMap::fillRandomly(uint32_t newColor, uint16_t numberOfPixels)
 
 void PixelMap::shiftPixelsRight()
 {
-    // Use signed int to avoid underflow when decrementing from 0
     for (int i = m_numPixels - 1; i >= 1; i--)
     {
         m_pixelColors[i] = m_pixelColors[i - 1];
@@ -258,78 +257,96 @@ void PixelMap::shiftPixelsLeft()
 
 void PixelMap::shiftColumnsRight()
 {
-    if (m_columns.size() == 0) return;  // Safety check
-    
+    shiftColumnsRight(0);
+}
+
+void PixelMap::shiftColumnsRight(uint16_t startingColumn)
+{
+    if (m_columns.size() == 0 || startingColumn >= m_columns.size() - 1) 
+    {
+        return;
+    }
+
     for (int row = 0; row < m_rows.size(); row++)
     {
-        for (int col = m_columns.size() - 1; col > 0; col--)
+        for (int col = m_columns.size() - 1; col > startingColumn; col--)
         {
             setColorInPixelMap(row, col, m_colorMap[row][col-1]);
         }
     }
 }
 
-// Update to use the new pixel map.
-// Currently only used by the CenterOut pattern.
-void PixelMap::shiftColumnsRight(uint32_t newColor, uint16_t startingColumn)
-{
-    shiftPixelBlocksRight(m_columns, newColor, startingColumn);
-}
-
 void PixelMap::shiftColumnsLeft()
 {
+    shiftColumnsLeft(m_columns.size() - 1);
+}
+
+void PixelMap::shiftColumnsLeft(uint16_t startingColumn)
+{
+    if (m_columns.size() == 0 || startingColumn == 0) 
+    {
+        return;
+    }
+
+    if (startingColumn >= m_columns.size())
+    {
+        startingColumn = m_columns.size() - 1;
+    }
+    
     for (int row = 0; row < m_rows.size(); row++)
     {
-        for (int col = 0; col < m_columns.size() - 1; col++)
+        for (int col = 0; col < startingColumn; col++)
         {
             setColorInPixelMap(row, col, m_colorMap[row][col+1]);
         }
     }
 }
 
-// Update to use the new pixel map.
-// Currently only used by the CenterOut pattern.
-void PixelMap::shiftColumnsLeft(uint32_t newColor, uint16_t startingColumn)
-{
-    shiftPixelBlocksLeft(m_columns, newColor, startingColumn);
-}
-
 void PixelMap::shiftRowsUp()
 {
+    shiftRowsUp(m_rows.size() - 1);
+}
+
+void PixelMap::shiftRowsUp(uint16_t startingRow)
+{
+    if (m_rows.size() == 0 || startingRow == 0)
+    {
+        return;
+    }
+
+    if (startingRow >= m_rows.size())
+    {
+        startingRow = m_rows.size() - 1;
+    }
+
     for (int col = 0; col < m_columns.size(); col++)
     {
-        for (int row = 0; row < m_rows.size() - 1; row++)
+        for (int row = 0; row < startingRow; row++)
         {
             setColorInPixelMap(row, col, m_colorMap[row+1][col]);
         }
     }
 }
 
-// Update to use the new pixel map.
-// Currently only used by the CenterOut pattern.
-void PixelMap::shiftRowsUp(uint32_t newColor, uint16_t startingRow)
-{
-    shiftPixelBlocksLeft(m_rows, newColor, startingRow);
-}
-
 void PixelMap::shiftRowsDown()
 {
-    if (m_rows.size() == 0) return;  // Safety check
-    
+    shiftRowsDown(0);
+}
+
+void PixelMap::shiftRowsDown(uint16_t startingRow)
+{
+    if (m_rows.size() == 0 || startingRow >= m_rows.size() - 1) 
+    {
+        return;
+    }
+
     for (int col = 0; col < m_columns.size(); col++)
     {
-        for (int row = m_rows.size() - 1; row > 0; row--)
+        for (int row = m_rows.size() - 1; row > startingRow; row--)
         {
             setColorInPixelMap(row, col, m_colorMap[row-1][col]);
         }
     }
-}
-
-// Update to use the new pixel map.
-// Currently only used by the CenterOut pattern.
-void PixelMap::shiftRowsDown(uint32_t newColor, uint16_t startingRow)
-{
-    shiftPixelBlocksRight(m_rows, newColor, startingRow);
 }
 
 void PixelMap::shiftDigitsRight()
@@ -375,72 +392,6 @@ void PixelMap::shiftDigitsLeft()
 
         uint32_t previousColor = m_pixelColors[m_digits.at(digit + 1)->at(0)];
         setDigitColor(digit, previousColor);
-    }
-}
-
-void PixelMap::shiftPixelBlocksRight(std::vector<std::vector<int> *> pixelBlocks, uint32_t newColor, uint16_t startingBlock)
-{
-    if (pixelBlocks.size() == 0) return;  // Safety check
-    
-    for (int i = pixelBlocks.size() - 1; i > (int)startingBlock; i--)
-    {
-        std::vector<int> *source = pixelBlocks.at(i - 1);
-        std::vector<int> *destination = pixelBlocks.at(i);
-        if (source->size() == 0 || destination->size() == 0)
-        {
-            // source or destination is empty -- skip it.
-            // this is an artifact of testing the new matrix code using empty rows/columns.
-            continue;
-        }
-
-        // Find the color of the first pixel in the source column, and set the destination column to that color.
-        uint32_t previousColor = m_pixelColors[source->at(0)];
-        setColorForMappedPixels(destination, previousColor);
-    }
-
-    if (startingBlock < pixelBlocks.size())
-    {
-        setColorForMappedPixels(pixelBlocks.at(startingBlock), newColor);
-    }
-}
-
-void PixelMap::shiftPixelBlocksLeft(std::vector<std::vector<int> *> pixelBlocks, uint32_t newColor, uint16_t startingBlock)
-{
-    // Ensure we don't go beyond the array bounds
-    uint16_t endBlock = (startingBlock < pixelBlocks.size()) ? startingBlock : pixelBlocks.size() - 1;
-    
-    for (uint16_t i = 0; i < endBlock; i++)
-    {
-        if (i + 1 >= pixelBlocks.size()) break;  // Safety check
-        
-        std::vector<int> *source = pixelBlocks.at(i + 1);
-        std::vector<int> *destination = pixelBlocks.at(i);
-        
-        if (source->size() == 0 || destination->size() == 0) continue;  // Skip empty blocks
-        
-        // Find the color of the first pixel in the source column, and set the destination column to that color.
-        uint32_t previousColor = m_pixelColors[source->at(0)];
-        setColorForMappedPixels(destination, previousColor);
-    }
-
-    if (startingBlock < pixelBlocks.size())
-    {
-        setColorForMappedPixels(pixelBlocks.at(startingBlock), newColor);
-    }
-}
-
-void PixelMap::setColorForMappedPixels(std::vector<int> *destination, uint32_t newColor)
-{
-    if (!destination) return;  // Null pointer check
-    
-    for (uint16_t i = 0; i < destination->size(); i++)
-    {
-        int pixelIndex = destination->at(i);
-        // Critical: validate pixelIndex is within bounds
-        if (pixelIndex >= 0 && pixelIndex < m_numPixels)
-        {
-            m_pixelColors[pixelIndex] = newColor;
-        }
     }
 }
 

--- a/lib/PixelMap/PixelMap.h
+++ b/lib/PixelMap/PixelMap.h
@@ -24,29 +24,21 @@ class PixelMap
 
         void shiftPixelsRight();
         void shiftPixelsLeft();
-
         void shiftColumnsRight();
+        void shiftColumnsRight(uint16_t startingColumn);
         void shiftColumnsLeft();
+        void shiftColumnsLeft(uint16_t startingColumn);
         void shiftRowsUp();
+        void shiftRowsUp(uint16_t startingRow);
         void shiftRowsDown();
+        void shiftRowsDown(uint16_t startingRow);
         void shiftDigitsRight();
         void shiftDigitsLeft();
 
-        // Sets the pixels in the starting column to the new color,
-        // shifting the columns to the right by one.
-        void shiftColumnsRight(uint32_t newColor, uint16_t startingColumn);
-
-        // Sets the pixels in the starting column to the new color,
-        // shifting the columns to the left by one.
-        void shiftColumnsLeft(uint32_t newColor, uint16_t startingColumn);
-
-        // Sets the pixels in the starting row to the new color,
-        // shifting subsequent the rows up by one.
-        void shiftRowsUp(uint32_t newColor, uint16_t startingRow);
-
-        // Sets the pixels in the starting row to the new color,
-        // shifting prior rows down by one.
-        void shiftRowsDown(uint32_t newColor, uint16_t startingRow);
+        uint16_t getPixelCount();
+        uint16_t getColumnCount();
+        uint16_t getRowCount();
+        uint16_t getDigitCount();
 
         // Sets a random assortment of pixels in the buffer to the given color.
         void fillRandomly(uint32_t newColor, uint16_t numberOfPixels);
@@ -54,31 +46,14 @@ class PixelMap
         // Sets the color of all pixels in the buffer to the given color.
         void fill(uint32_t newColor);
 
-        // Gets the number of pixels in the buffer.
-        uint16_t getPixelCount();
-
-        // Gets the number of columns in the buffer.
-        // Might not be needed?
-        uint16_t getColumnCount();
-
-        // Gets the number of Rows in the buffer.
-        // Might not be needed?
-        uint16_t getRowCount();
-
-        uint16_t getDigitCount();
-
         // Set an individual pixel in the raw pixel buffer to a color.
-        void setRawPixel(uint16_t pixel, uint32_t color);
+        void setRawPixelColor(uint16_t pixel, uint32_t color);
 
         // Set the color of a specific pixel in the row/column map.
         void setColorInPixelMap(uint16_t row, uint16_t column, uint32_t color);
 
-        // Set all pixels in the given row to the given color.
         void setRowColor(uint16_t row, uint32_t newColor);
-        
-        // Set all pixels in the given column to the given color.
         void setColumnColor(uint16_t column, uint32_t newColor);
-
         void setDigitColor(uint16_t digit, uint32_t newColor);
 
         // Get the row-to-pixel mapping for all rows.
@@ -89,6 +64,7 @@ class PixelMap
 
         // Get the row-to-pixel mapping for a specific digit.
         // This method calculates the intersection of rows and digits, and can be expensive to call.
+        // (Used only by the Fire pattern, and only for a style that's not often used.)
         const std::vector<std::vector<int>*> getRowsForDigit(uint16_t digit);
         
         // Clears the internal pixel buffer.
@@ -110,9 +86,6 @@ class PixelMap
         void initializeFromConfiguration(const DisplayConfiguration& displayConfiguration);
         void initializeInternalMaps();
         void setRowAndColumnForPixel(uint16_t pixel, uint16_t row, uint16_t column);
-        void setColorForMappedPixels(std::vector<int>* destination, uint32_t newColor);
-        void shiftPixelBlocksRight(std::vector<std::vector<int>*> pixelBlocks, uint32_t newColor, uint16_t startingBlock);
-        void shiftPixelBlocksLeft(std::vector<std::vector<int>*> pixelBlocks, uint32_t newColor, uint16_t startingBlock);
         
         // Maps a row and column to a pixel buffer index, or -1 if no pixel at that location.
         std::vector<std::vector<int>> m_pixelMap;

--- a/lib/PixelMap/PixelMap.h
+++ b/lib/PixelMap/PixelMap.h
@@ -22,14 +22,7 @@ class PixelMap
         void setColsToLeft(uint16_t colsToLeft) { m_colsToLeft = colsToLeft; }
         void setColsToRight(uint16_t colsToRight) { m_colsToRight = colsToRight; }
 
-        // Sets the first pixel in the buffer to the new color,
-        // shifting all the pixels in the buffer to the right by one.
-        void shiftPixelsRight(uint32_t newColor);
         void shiftPixelsRight();
-
-        // Sets the last pixel in the buffer to the new color,
-        // shifting all the pixels in the buffer to the left by one.
-        void shiftPixelsLeft(uint32_t newColor);
         void shiftPixelsLeft();
 
         void shiftColumnsRight();
@@ -39,41 +32,21 @@ class PixelMap
         void shiftDigitsRight();
         void shiftDigitsLeft();
 
-        // Sets the pixels in the first column to the new color,
-        // shifting all the columns to the right by one.
-        void shiftColumnsRight(uint32_t newColor);
-
         // Sets the pixels in the starting column to the new color,
         // shifting the columns to the right by one.
         void shiftColumnsRight(uint32_t newColor, uint16_t startingColumn);
-
-        // Sets the pixels in the last column to the new color,
-        // shifting all the columns to the left by one.
-        void shiftColumnsLeft(uint32_t newColor);
 
         // Sets the pixels in the starting column to the new color,
         // shifting the columns to the left by one.
         void shiftColumnsLeft(uint32_t newColor, uint16_t startingColumn);
 
-        // Sets the pixels in the bottom row to the new color,
-        // shifting all the rows up by one.
-        void shiftRowsUp(uint32_t newColor);
-
         // Sets the pixels in the starting row to the new color,
         // shifting subsequent the rows up by one.
         void shiftRowsUp(uint32_t newColor, uint16_t startingRow);
 
-        // Sets the pixels in the top row to the new color,
-        // shifting all the rows down by one.
-        void shiftRowsDown(uint32_t newColor);
-
         // Sets the pixels in the starting row to the new color,
         // shifting prior rows down by one.
         void shiftRowsDown(uint32_t newColor, uint16_t startingRow);
-
-        // Sets the pixels in the leftmost digit to the new color,
-        // shifting all the digit colors one place to the right.
-        void shiftDigitsRight(uint32_t newColor);
 
         // Sets a random assortment of pixels in the buffer to the given color.
         void fillRandomly(uint32_t newColor, uint16_t numberOfPixels);

--- a/lib/PixelMap/PixelMap.h
+++ b/lib/PixelMap/PixelMap.h
@@ -25,10 +25,19 @@ class PixelMap
         // Sets the first pixel in the buffer to the new color,
         // shifting all the pixels in the buffer to the right by one.
         void shiftPixelsRight(uint32_t newColor);
+        void shiftPixelsRight();
 
         // Sets the last pixel in the buffer to the new color,
         // shifting all the pixels in the buffer to the left by one.
         void shiftPixelsLeft(uint32_t newColor);
+        void shiftPixelsLeft();
+
+        void shiftColumnsRight();
+        void shiftColumnsLeft();
+        void shiftRowsUp();
+        void shiftRowsDown();
+        void shiftDigitsRight();
+        void shiftDigitsLeft();
 
         // Sets the pixels in the first column to the new color,
         // shifting all the columns to the right by one.
@@ -86,7 +95,7 @@ class PixelMap
         uint16_t getDigitCount();
 
         // Set an individual pixel in the raw pixel buffer to a color.
-        void setPixel(uint16_t pixel, uint32_t color);
+        void setRawPixel(uint16_t pixel, uint32_t color);
 
         // Set the color of a specific pixel in the row/column map.
         void setColorInPixelMap(uint16_t row, uint16_t column, uint32_t color);
@@ -96,6 +105,8 @@ class PixelMap
         
         // Set all pixels in the given column to the given color.
         void setColumnColor(uint16_t column, uint32_t newColor);
+
+        void setDigitColor(uint16_t digit, uint32_t newColor);
 
         // Get the row-to-pixel mapping for all rows.
         const std::vector<std::vector<int>*>& getAllRows();
@@ -110,7 +121,7 @@ class PixelMap
         // Clears the internal pixel buffer.
         void clearBuffer();
 
-        uint32_t getPixel(uint16_t pixel);
+        uint32_t getRawPixelColor(uint16_t pixel);
 
     private:
         uint16_t m_numPixels{0};       // Size of internal buffer


### PR DESCRIPTION
Updating methods to use the row/column pixel map when shifting pixels.
Breaking "combination" methods that shift and set colors to separate methods.