### PR TITLE
Merging Secondary logic into Legacy Controller

### DIFF
--- a/LegacySignController/src/Bluetooth/SecondaryPeripheral.cpp
+++ b/LegacySignController/src/Bluetooth/SecondaryPeripheral.cpp
@@ -1,0 +1,33 @@
+#include "SecondaryPeripheral.h"
+
+SecondaryPeripheral::SecondaryPeripheral()
+{
+    m_additionalCharacteristics.push_back(m_signConfigurationCharacteristic);
+    m_additionalCharacteristics.push_back(m_signOffsetDataCharacteristic);
+    m_additionalCharacteristics.push_back(m_syncDataCharacteristic);
+    m_additionalCharacteristics.push_back(m_timestampCharacteristic);
+
+    m_syncDataCharacteristic.writeValue(0);
+}
+
+void SecondaryPeripheral::setSignConfigurationData(const SignConfigurationData& data)
+{
+    m_signConfigurationCharacteristic.writeValue(&data, sizeof(data));
+}
+
+SignOffsetData SecondaryPeripheral::getSignOffsetData()
+{
+    m_signOffsetDataCharacteristic.readValue(&m_currentOffsetData, sizeof(m_currentOffsetData));
+    return m_currentOffsetData;
+}
+
+ulong SecondaryPeripheral::getSyncData()
+{
+    m_currentSyncData = readULongFromCharacteristic(m_syncDataCharacteristic, m_currentSyncData, "SyncData");
+    return m_currentSyncData;
+}
+
+void SecondaryPeripheral::emitTimestamp(ulong timestamp)
+{
+    m_timestampCharacteristic.writeValue(timestamp);
+}

--- a/LegacySignController/src/Bluetooth/SecondaryPeripheral.h
+++ b/LegacySignController/src/Bluetooth/SecondaryPeripheral.h
@@ -1,0 +1,27 @@
+#ifndef SECONDARYPERIPHERAL_H
+#define SECONDARYPERIPHERAL_H
+
+#include <Arduino.h>
+#include <ArduinoBLE.h>
+#include <BluetoothCommon.h>
+#include <SignConfigurationData.h>
+#include <SignOffsetData.h>
+
+class SecondaryPeripheral : public CommonPeripheral {
+  public:
+    SecondaryPeripheral();
+    void setSignConfigurationData(const SignConfigurationData& data);
+    SignOffsetData getSignOffsetData();
+    ulong getSyncData();
+    void emitTimestamp(ulong timestamp);
+
+  private:
+    SignOffsetData m_currentOffsetData;
+    ulong m_currentSyncData{0};
+    BLECharacteristic m_signConfigurationCharacteristic{ BTCOMMON_SIGNCONFIGURATION_CHARACTERISTIC_UUID, BLERead, sizeof(SignConfigurationData) };
+    BLECharacteristic m_signOffsetDataCharacteristic{ BTCOMMON_OFFSETDATA_CHARACTERISTIC_UUID, BLERead | BLEWrite, sizeof(SignOffsetData) };
+    BLEUnsignedLongCharacteristic m_syncDataCharacteristic{ BTCOMMON_SYNCDATA_CHARACTERISTIC_UUID, BLERead | BLEWrite };
+    BLEUnsignedLongCharacteristic m_timestampCharacteristic{ BTCOMMON_TIMESTAMP_CHARACTERISTIC_UUID, BLERead };
+};
+
+#endif

--- a/LegacySignController/src/NeoPixelDisplay.cpp
+++ b/LegacySignController/src/NeoPixelDisplay.cpp
@@ -34,6 +34,16 @@ void NeoPixelDisplay::setDisplayPattern(DisplayPattern* displayPattern)
     }
 }
 
+uint16_t NeoPixelDisplay::getPixelCount()
+{
+    if (m_pixelMap == nullptr) 
+    {
+        return 0;
+    }
+
+    return m_pixelMap->getPixelCount();
+}
+
 uint16_t NeoPixelDisplay::getColumnCount()
 {
     if (m_pixelMap == nullptr) 

--- a/LegacySignController/src/NeoPixelDisplay.cpp
+++ b/LegacySignController/src/NeoPixelDisplay.cpp
@@ -34,6 +34,36 @@ void NeoPixelDisplay::setDisplayPattern(DisplayPattern* displayPattern)
     }
 }
 
+uint16_t NeoPixelDisplay::getColumnCount()
+{
+    if (m_pixelMap == nullptr) 
+    {
+        return 0;
+    }
+
+    return m_pixelMap->getColumnCount();
+}
+
+uint16_t NeoPixelDisplay::getRowCount()
+{
+    if (m_pixelMap == nullptr) 
+    {
+        return 0;
+    }
+
+    return m_pixelMap->getRowCount();
+}
+
+uint16_t NeoPixelDisplay::getDigitCount()
+{
+    if (m_pixelMap == nullptr) 
+    {
+        return 0;
+    }
+
+    return m_pixelMap->getDigitCount();
+}
+
 void NeoPixelDisplay::setDigitsToLeft(uint16_t digitsToLeft)
 {
     m_pixelMap->setDigitsToLeft(digitsToLeft);

--- a/LegacySignController/src/NeoPixelDisplay.h
+++ b/LegacySignController/src/NeoPixelDisplay.h
@@ -20,6 +20,9 @@ class NeoPixelDisplay
         DisplayPattern* getDisplayPattern() { return m_displayPattern; }
         void updateDisplay();
         void resetDisplay();
+        uint16_t getColumnCount();
+        uint16_t getRowCount();
+        uint16_t getDigitCount();
 
         void setDigitsToLeft(uint16_t digitsToLeft);
         void setDigitsToRight(uint16_t digitsToRight);

--- a/LegacySignController/src/NeoPixelDisplay.h
+++ b/LegacySignController/src/NeoPixelDisplay.h
@@ -20,6 +20,7 @@ class NeoPixelDisplay
         DisplayPattern* getDisplayPattern() { return m_displayPattern; }
         void updateDisplay();
         void resetDisplay();
+        uint16_t getPixelCount();
         uint16_t getColumnCount();
         uint16_t getRowCount();
         uint16_t getDigitCount();

--- a/LegacySignController/src/main.cpp
+++ b/LegacySignController/src/main.cpp
@@ -357,6 +357,7 @@ void initializeBLEService(BluetoothConfiguration& config)
         // Not exactly sure how to handle multiple displays...
         signConfigData.columnCount = neoPixelDisplays->at(0)->getColumnCount();
         signConfigData.digitCount = neoPixelDisplays->at(0)->getDigitCount();
+        signConfigData.pixelCount = neoPixelDisplays->at(0)->getPixelCount();
     }
 
     btService.setSignConfigurationData(signConfigData);

--- a/LegacySignController/src/main.h
+++ b/LegacySignController/src/main.h
@@ -3,7 +3,7 @@
 #include <SD.h>
 #include <vector>
 #include <algorithm>
-#include <BluetoothCommon.h>
+#include "Bluetooth\SecondaryPeripheral.h"
 #include <DisplayPatternLib.h>
 #include <StatusDisplayLib.h>
 #include "ArduinoPushButton/ArduinoPushButton.h"
@@ -59,12 +59,13 @@ byte getSignPosition();
 const char* readBuiltInFile(String filename);
 const char* copyString(const char* source, size_t length);
 
-const char* defaultSystemConfigJson = R"json(
+const char* defaultSystemConfigJsonForSecondaries = R"json(
     {
         "displayConfigurationFile": "::Display[[SIGNTYPE]]::",
         "styleConfigurationFile": "::[[STYLECONFIGTYPENAME]]::",
         "bluetooth": {
             "enabled": true,
+            "isSecondaryModeEnabled": true
             "uuid": "1221ca8d-4172-4946-bcd1-f9e4b40ba6b0",
             "localName": "3181 LED Controller [[SIGNPOSITION]]-[[SIGNTYPE]]"
         },
@@ -79,6 +80,7 @@ const char* defaultSystemConfigJson = R"json(
     }
 )json";
 
+// Not needed ???  We should assume we can read the config from the SD card.
 const char* legacyButtonDefinitionJson = R"json(
         "definitions": [
             {

--- a/LegacySignController/src/main.h
+++ b/LegacySignController/src/main.h
@@ -39,10 +39,10 @@ SystemConfiguration* readSystemConfiguration();
 StatusDisplay* createStatusDisplay(Tm1637DisplayConfiguration& config);
 std::vector<NeoPixelDisplay*>* createNeoPixelDisplays(String displayConfigFile);
 StyleConfiguration* readStyleConfiguration(String styleConfigFile);
-void initializeBatteryMonitor(BatteryMonitorConfiguration& config);
+void initializeBatteryMonitor(const BatteryMonitorConfiguration& config);
 void initializeDefaultStyleProperties(StyleDefinition& defaultStyleDefinition);
 void initializeBLEService(BluetoothConfiguration& config);
-void configurePowerLed(PowerLedConfiguration& config);
+void initializePowerLed(const PowerLedConfiguration& config);
 void readSettingsFromBLE();
 void setManualStyle(StyleDefinition styleDefinition);
 void updateTelemetry();
@@ -61,13 +61,13 @@ const char* copyString(const char* source, size_t length);
 
 const char* defaultSystemConfigJsonForSecondaries = R"json(
     {
-        "displayConfigurationFile": "::Display[[SIGNTYPE]]::",
+        "displayConfigurationFile": "::Display[[SIGNTYPE1]]::",
         "styleConfigurationFile": "::[[STYLECONFIGTYPENAME]]::",
         "bluetooth": {
             "enabled": true,
-            "isSecondaryModeEnabled": true
+            "isSecondaryModeEnabled": true,
             "uuid": "1221ca8d-4172-4946-bcd1-f9e4b40ba6b0",
-            "localName": "3181 LED Controller [[SIGNPOSITION]]-[[SIGNTYPE]]"
+            "localName": "3181 LED Controller [[SIGNPOSITION]]-[[SIGNTYPE2]]"
         },
         "buttons": {[[BUTTONS]]},
         "batteryMonitor": {
@@ -163,9 +163,7 @@ const char* defaultPrimaryButtonDefinitionJson = R"json(
             {
                 "buttonIds": ["3"],
                 "tapAction": "changeStyle",
-                "tapActionArguments": ["RedPinkRandom_Large", "RedPinkDigit"],
-                "longTapAction": "disconnectBT",
-                "longTapActionArguments": []
+                "tapActionArguments": ["RedPinkRandom_Large", "RedPinkDigit"]
             },
             {
                 "buttonIds": ["4"],
@@ -176,9 +174,7 @@ const char* defaultPrimaryButtonDefinitionJson = R"json(
             },
             {
                 "buttonIds": ["3", "4"],
-                "tapAction": "changeStyle",
                 "longTapAction": "resetSecondaries"
             }
         ]
-    }
 )json";

--- a/LegacySignController/test/test_SystemConfiguration/SystemConfigurationTests.cpp
+++ b/LegacySignController/test/test_SystemConfiguration/SystemConfigurationTests.cpp
@@ -149,6 +149,7 @@ void minimalJsonSetsProperties() {
     TEST_ASSERT_TRUE_MESSAGE(btc.isEnabled(), "BluetoothConfiguration should be enabled by default.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE("99be4fac-c708-41e5-a149-74047f554cc1", btc.getUuid().c_str(), "Bluetooth UUID is not the expected default value.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE("LED Sign Controller", btc.getLocalName().c_str(), "Bluetooth local name is not the expected default value.");
+    TEST_ASSERT_FALSE_MESSAGE(btc.isSecondaryModeEnabled(), "Secondary mode should be disabled by default.");
     delete sc;
 }
 
@@ -256,6 +257,7 @@ void additionalConfigurationsAreParsed() {
     TEST_ASSERT_FALSE_MESSAGE(btc.isEnabled(), "BluetoothConfiguration should be disabled.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE("a32090db-3b1f-44f6-8b37-37a28b1a44dd", btc.getUuid().c_str(), "Bluetooth UUID is not correct.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE("My LED Sign", btc.getLocalName().c_str(), "Bluetooth local name is not correct.");
+    TEST_ASSERT_TRUE_MESSAGE(btc.isSecondaryModeEnabled(), "Secondary mode should be enabled.");
     delete sc;
 }
 
@@ -362,7 +364,8 @@ const char* additionalConfigurations()
             "bluetooth": {
                 "enabled": false,
                 "uuid": "a32090db-3b1f-44f6-8b37-37a28b1a44dd",
-                "localName": "My LED Sign"
+                "localName": "My LED Sign",
+                "isSecondaryModeEnabled": true
             },
             "batteryMonitor": {
                 "enabled": true,

--- a/lib/Configuration/BluetoothConfiguration.cpp
+++ b/lib/Configuration/BluetoothConfiguration.cpp
@@ -4,11 +4,12 @@ BluetoothConfiguration::BluetoothConfiguration()
 {
 }
 
-BluetoothConfiguration::BluetoothConfiguration(bool isEnabled, String uuid, String localName)
+BluetoothConfiguration::BluetoothConfiguration(bool isEnabled, String uuid, String localName, bool isSecondaryModeEnabled)
 {
     m_enabled = isEnabled;
     m_uuid = uuid;
     m_localName = localName;
+    m_secondaryModeEnabled = isSecondaryModeEnabled;
 }
 
 BluetoothConfiguration::BluetoothConfiguration(const BluetoothConfiguration& other)
@@ -28,4 +29,5 @@ void BluetoothConfiguration::copy(const BluetoothConfiguration& other)
     this->m_enabled = other.m_enabled;
     this->m_uuid = other.m_uuid;
     this->m_localName = other.m_localName;
+    this->m_secondaryModeEnabled = other.m_secondaryModeEnabled;
 }

--- a/lib/Configuration/BluetoothConfiguration.h
+++ b/lib/Configuration/BluetoothConfiguration.h
@@ -9,11 +9,12 @@ class BluetoothConfiguration
     public:
         BluetoothConfiguration();
         BluetoothConfiguration(const BluetoothConfiguration& other);
-        BluetoothConfiguration(bool isEnabled, String uuid, String localName);
+        BluetoothConfiguration(bool isEnabled, String uuid, String localName, bool secondaryModeEnabled);
         
         bool isEnabled() { return m_enabled; }
         String getUuid() { return m_uuid; }
         String getLocalName() { return m_localName; }
+        bool isSecondaryModeEnabled() { return m_secondaryModeEnabled; }
 
         BluetoothConfiguration& operator=(const BluetoothConfiguration& other);
 
@@ -23,6 +24,7 @@ class BluetoothConfiguration
         bool m_enabled{true};
         String m_uuid{"99be4fac-c708-41e5-a149-74047f554cc1"};
         String m_localName{"LED Sign Controller"};
+        bool m_secondaryModeEnabled{false};
 };
 
 #endif

--- a/lib/Configuration/SystemConfiguration.cpp
+++ b/lib/Configuration/SystemConfiguration.cpp
@@ -327,6 +327,7 @@ BluetoothConfiguration SystemConfiguration::parseBluetoothConfiguration(JsonVari
     bool enabled = defaultBtc.isEnabled();
     String uuid = defaultBtc.getUuid();
     String localName = defaultBtc.getLocalName();
+    bool isSecondaryModeEnabled = defaultBtc.isSecondaryModeEnabled();
     
     if (btcVariant["enabled"].is<JsonVariant>())
     {
@@ -345,8 +346,14 @@ BluetoothConfiguration SystemConfiguration::parseBluetoothConfiguration(JsonVari
         localName = String(localNamestr.c_str());
     }
 
+    if (btcVariant["isSecondaryModeEnabled"].is<JsonVariant>())
+    {
+        isSecondaryModeEnabled = btcVariant["isSecondaryModeEnabled"].as<bool>();
+    }
+
     return BluetoothConfiguration(
         enabled,
         uuid,
-        localName);
+        localName,
+        isSecondaryModeEnabled);
 }


### PR DESCRIPTION
There are currently 3 workspaces with 3 different main.cpp files: One for the Primary controller, one for the Secondary controller, and one for the Legacy sign.  The workspaces were separate because they needed slightly different logic and had different pinouts.  With the recent change to allow the Legacy controller to read its configuration from a microSD card, it's now possible to merge the logic for the Secondary controller and the Legacy controller into the same workspace.

A subsequent update is planned to make the Primary controller get its configuration from a microSD card, at which point it might be possible to merge it into the common logic and have a single workspace.