### PR TITLE
Restructure the secondary BT logic a bit

### DIFF
--- a/LegacySignController/src/main.cpp
+++ b/LegacySignController/src/main.cpp
@@ -359,7 +359,7 @@ void initializeBLEService(const BluetoothConfiguration& config)
     blePeripheralService->setColorPatternList(PatternFactory::getKnownColorPatterns());
     blePeripheralService->setDisplayPatternList(PatternFactory::getKnownDisplayPatterns());
     
-    if (bluetoothConfig.isSecondaryModeEnabled() && neoPixelDisplays->size() > 0)
+    if (bluetoothConfig.isSecondaryModeEnabled())
     {
         SignConfigurationData signConfigData;
         if (neoPixelDisplays->size() > 0) {

--- a/LegacySignController/src/main.cpp
+++ b/LegacySignController/src/main.cpp
@@ -1,16 +1,15 @@
 #include "main.h"
 
 // Global variables
-SecondaryPeripheral btService;
+CommonPeripheral* blePeripheralService = nullptr;
 StatusDisplay* display;
 std::vector<NeoPixelDisplay*>* neoPixelDisplays;
 ButtonProcessor* buttonProcessor;
 StyleConfiguration* styleConfiguration;
 BatteryMonitorConfiguration batteryMonitorConfig;
 PowerLedConfiguration powerLedConfig;
+BluetoothConfiguration bluetoothConfig;
 
-bool isBluetoothEnabled = false;
-bool isSecondaryModeEnabled = false;
 ulong loopCounter = 0;
 ulong lastTelemetryTimestamp = 0;
 ulong ledLoopCounter = 0;
@@ -90,7 +89,7 @@ void loop()
     updateTelemetry();
     checkForLowPowerState();
 
-    if (isBluetoothEnabled && btService.isConnected())
+    if (bluetoothConfig.isEnabled() && blePeripheralService->isConnected())
     {
         // Something is connected via BT.
         // Set the display to "--" to show something connected to us.
@@ -306,16 +305,17 @@ void setManualStyle(StyleDefinition styleDefinition)
     newPatternData = styleDefinition.getPatternData();
 
     // Update the local BLE settings to reflect the new manual settings.
-    if (isBluetoothEnabled)
+    if (bluetoothConfig.isEnabled())
     {
-        btService.setSpeed(newSpeed);
-        btService.setPatternData(newPatternData);
+        blePeripheralService->setSpeed(newSpeed);
+        blePeripheralService->setPatternData(newPatternData);
     }
 }
 
-void initializeBLEService(BluetoothConfiguration& config)
+void initializeBLEService(const BluetoothConfiguration& config)
 {
-    if (!config.isEnabled())
+    bluetoothConfig = config;
+    if (!bluetoothConfig.isEnabled())
     {
         Serial.println("Bluetooth is disabled in configuration.");
         display->setDisplay("boff");
@@ -335,50 +335,63 @@ void initializeBLEService(BluetoothConfiguration& config)
     }
 
     display->setDisplay("C  =");
-    Serial.println("Setting up Peripheral service using common logic.");
-    btService.initialize(config.getUuid(), config.getLocalName());
+    if (bluetoothConfig.isSecondaryModeEnabled())
+    {
+        // Initialize the secondary peripheral service.
+        Serial.println("Initializing secondary peripheral service.");
+        blePeripheralService = new SecondaryPeripheral();
+    }
+    else
+    {
+        // Initialize the common peripheral service.
+        Serial.println("Initializing common peripheral service.");
+        blePeripheralService = new CommonPeripheral();
+    }
+
+    blePeripheralService->initialize(bluetoothConfig.getUuid(), bluetoothConfig.getLocalName());
 
     // Set the various characteristics based on the defaults
     display->setDisplay("C ==");
 
-    btService.setBrightness(currentBrightness);
-    btService.setSpeed(currentSpeed);
-    btService.setPatternData(currentPatternData);
-    btService.setColorPatternList(PatternFactory::getKnownColorPatterns());
-    btService.setDisplayPatternList(PatternFactory::getKnownDisplayPatterns());
+    blePeripheralService->setBrightness(currentBrightness);
+    blePeripheralService->setSpeed(currentSpeed);
+    blePeripheralService->setPatternData(currentPatternData);
+    blePeripheralService->setColorPatternList(PatternFactory::getKnownColorPatterns());
+    blePeripheralService->setDisplayPatternList(PatternFactory::getKnownDisplayPatterns());
     
-    isSecondaryModeEnabled = config.isSecondaryModeEnabled();
-    SignConfigurationData signConfigData;
-    if (isSecondaryModeEnabled && neoPixelDisplays->size() > 0) {
-        // The assumption here is that if we're in secondary mode, the configuration is read from the pins.
-        signConfigData.signType = getSignType();
-        signConfigData.signOrder = getSignPosition();
-        
-        // Not exactly sure how to handle multiple displays...
-        signConfigData.columnCount = neoPixelDisplays->at(0)->getColumnCount();
-        signConfigData.digitCount = neoPixelDisplays->at(0)->getDigitCount();
-        signConfigData.pixelCount = neoPixelDisplays->at(0)->getPixelCount();
+    if (bluetoothConfig.isSecondaryModeEnabled() && neoPixelDisplays->size() > 0)
+    {
+        SignConfigurationData signConfigData;
+        if (neoPixelDisplays->size() > 0) {
+            // The assumption here is that if we're in secondary mode, the configuration is read from the pins.
+            signConfigData.signType = getSignType();
+            signConfigData.signOrder = getSignPosition();
+            
+            // Not exactly sure how to handle multiple displays...
+            signConfigData.columnCount = neoPixelDisplays->at(0)->getColumnCount();
+            signConfigData.digitCount = neoPixelDisplays->at(0)->getDigitCount();
+            signConfigData.pixelCount = neoPixelDisplays->at(0)->getPixelCount();
+        }
+
+        ((SecondaryPeripheral*)blePeripheralService)->setSignConfigurationData(signConfigData);
     }
 
-    btService.setSignConfigurationData(signConfigData);
-
-    isBluetoothEnabled = true;
     Serial.println("Peripheral service started.");
 }
 
 void readSettingsFromBLE()
 {
-    if (!isBluetoothEnabled)
+    if (!bluetoothConfig.isEnabled())
     {
         return;
     }
 
     BLE.poll();
-    if (isSecondaryModeEnabled)
+    if (bluetoothConfig.isSecondaryModeEnabled())
     {
-        newSyncData = btService.getSyncData();
+        newSyncData = ((SecondaryPeripheral*)blePeripheralService)->getSyncData();
 
-        SignOffsetData newOffsetData = btService.getSignOffsetData();
+        SignOffsetData newOffsetData = ((SecondaryPeripheral*)blePeripheralService)->getSignOffsetData();
         if (newOffsetData != currentOffsetData && neoPixelDisplays->size() > 0)
         {
             // Secondary offsets don't really handle multiple displays well.
@@ -391,9 +404,9 @@ void readSettingsFromBLE()
         }
     }
 
-    newBrightness = btService.getBrightness();
-    newSpeed = btService.getSpeed();
-    newPatternData = btService.getPatternData();
+    newBrightness = blePeripheralService->getBrightness();
+    newSpeed = blePeripheralService->getSpeed();
+    newPatternData = blePeripheralService->getPatternData();
 }
 
 void initializeBatteryMonitor(const BatteryMonitorConfiguration& config)
@@ -537,7 +550,11 @@ void updateTelemetry()
         float voltage = getCalculatedBatteryVoltage();
 
         // Emit battery voltage information on Bluetooth as well as Serial.
-        btService.emitBatteryVoltage(voltage);
+        if (bluetoothConfig.isEnabled())
+        {
+            blePeripheralService->emitBatteryVoltage(voltage);
+        }
+
         Serial.print("Battery monitor: ");
         Serial.print(batteryMonitorConfig.isEnabled() ? "Enabled" : "Disabled");
         Serial.print("; Raw input: ");
@@ -545,8 +562,11 @@ void updateTelemetry()
         Serial.print("; Calculated voltage: ");
         Serial.println(voltage);
 
-        Serial.print("Bluetooth connected: ");
-        Serial.println(btService.isConnected());
+        if (bluetoothConfig.isEnabled())
+        {
+            Serial.print("Bluetooth connected: ");
+            Serial.println(blePeripheralService->isConnected());
+        }
     }
 }
 
@@ -581,7 +601,7 @@ void updateLEDs()
 {
     bool shouldUpdate = false;
 
-    if (isSecondaryModeEnabled)
+    if (bluetoothConfig.isSecondaryModeEnabled())
     {
         // We're in secondary mode, so only update when the sync data changes.
         if (newSyncData != currentSyncData)
@@ -607,7 +627,7 @@ void updateLEDs()
         {
             neoPixelDisplay->setBrightness(newBrightness);
             // If we're in secondary mode, force a reset of the display pattern even if the pattern didn't change.
-            if (isSecondaryModeEnabled || currentPatternData != newPatternData)
+            if (bluetoothConfig.isSecondaryModeEnabled() || currentPatternData != newPatternData)
             {
                 DisplayPattern* newPattern = PatternFactory::createForPatternData(newPatternData);
                 neoPixelDisplay->setDisplayPattern(newPattern);
@@ -641,9 +661,9 @@ void processButtonAction(int callerId, String actionName, std::vector<String> ar
         return;
     }
 
-    if (actionName == "disconnectBT")
+    if (actionName == "disconnectBT" && bluetoothConfig.isEnabled())
     {
-        btService.disconnect();
+        blePeripheralService->disconnect();
         return;
     }
 

--- a/LegacySignController/src/main.h
+++ b/LegacySignController/src/main.h
@@ -41,7 +41,7 @@ std::vector<NeoPixelDisplay*>* createNeoPixelDisplays(String displayConfigFile);
 StyleConfiguration* readStyleConfiguration(String styleConfigFile);
 void initializeBatteryMonitor(const BatteryMonitorConfiguration& config);
 void initializeDefaultStyleProperties(StyleDefinition& defaultStyleDefinition);
-void initializeBLEService(BluetoothConfiguration& config);
+void initializeBLEService(const BluetoothConfiguration& config);
 void initializePowerLed(const PowerLedConfiguration& config);
 void readSettingsFromBLE();
 void setManualStyle(StyleDefinition styleDefinition);

--- a/LegacySignController/test/test_SystemConfiguration/SystemConfigurationTests.cpp
+++ b/LegacySignController/test/test_SystemConfiguration/SystemConfigurationTests.cpp
@@ -150,6 +150,7 @@ void minimalJsonSetsProperties() {
     TEST_ASSERT_EQUAL_STRING_MESSAGE("99be4fac-c708-41e5-a149-74047f554cc1", btc.getUuid().c_str(), "Bluetooth UUID is not the expected default value.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE("LED Sign Controller", btc.getLocalName().c_str(), "Bluetooth local name is not the expected default value.");
     TEST_ASSERT_FALSE_MESSAGE(btc.isSecondaryModeEnabled(), "Secondary mode should be disabled by default.");
+    TEST_ASSERT_FALSE_MESSAGE(btc.isProxyModeEnabled(), "Proxy mode should be disabled by default.");
     delete sc;
 }
 
@@ -258,6 +259,7 @@ void additionalConfigurationsAreParsed() {
     TEST_ASSERT_EQUAL_STRING_MESSAGE("a32090db-3b1f-44f6-8b37-37a28b1a44dd", btc.getUuid().c_str(), "Bluetooth UUID is not correct.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE("My LED Sign", btc.getLocalName().c_str(), "Bluetooth local name is not correct.");
     TEST_ASSERT_TRUE_MESSAGE(btc.isSecondaryModeEnabled(), "Secondary mode should be enabled.");
+    TEST_ASSERT_TRUE_MESSAGE(btc.isProxyModeEnabled(), "Proxy mode should be enabled.");
     delete sc;
 }
 
@@ -365,7 +367,8 @@ const char* additionalConfigurations()
                 "enabled": false,
                 "uuid": "a32090db-3b1f-44f6-8b37-37a28b1a44dd",
                 "localName": "My LED Sign",
-                "isSecondaryModeEnabled": true
+                "isSecondaryModeEnabled": true,
+                "isProxyModeEnabled": true
             },
             "batteryMonitor": {
                 "enabled": true,

--- a/lib/Configuration/BluetoothConfiguration.cpp
+++ b/lib/Configuration/BluetoothConfiguration.cpp
@@ -4,12 +4,13 @@ BluetoothConfiguration::BluetoothConfiguration()
 {
 }
 
-BluetoothConfiguration::BluetoothConfiguration(bool isEnabled, String uuid, String localName, bool isSecondaryModeEnabled)
+BluetoothConfiguration::BluetoothConfiguration(bool isEnabled, String uuid, String localName, bool isSecondaryModeEnabled, bool isProxyModeEnabled)
 {
     m_enabled = isEnabled;
     m_uuid = uuid;
     m_localName = localName;
     m_secondaryModeEnabled = isSecondaryModeEnabled;
+    m_proxyModeEnabled = isProxyModeEnabled;
 }
 
 BluetoothConfiguration::BluetoothConfiguration(const BluetoothConfiguration& other)
@@ -30,4 +31,5 @@ void BluetoothConfiguration::copy(const BluetoothConfiguration& other)
     this->m_uuid = other.m_uuid;
     this->m_localName = other.m_localName;
     this->m_secondaryModeEnabled = other.m_secondaryModeEnabled;
+    this->m_proxyModeEnabled = other.m_proxyModeEnabled;
 }

--- a/lib/Configuration/BluetoothConfiguration.h
+++ b/lib/Configuration/BluetoothConfiguration.h
@@ -9,22 +9,25 @@ class BluetoothConfiguration
     public:
         BluetoothConfiguration();
         BluetoothConfiguration(const BluetoothConfiguration& other);
-        BluetoothConfiguration(bool isEnabled, String uuid, String localName, bool secondaryModeEnabled);
+        BluetoothConfiguration(bool isEnabled, String uuid, String localName, bool secondaryModeEnabled, bool proxyModeEnabled);
         
         bool isEnabled() { return m_enabled; }
         String getUuid() { return m_uuid; }
         String getLocalName() { return m_localName; }
         bool isSecondaryModeEnabled() { return m_secondaryModeEnabled; }
+        bool isProxyModeEnabled() { return m_proxyModeEnabled; }
 
         BluetoothConfiguration& operator=(const BluetoothConfiguration& other);
 
     private:
         void copy(const BluetoothConfiguration& other);
 
+        // Default to "primary" / "standalone" mode
         bool m_enabled{true};
         String m_uuid{"99be4fac-c708-41e5-a149-74047f554cc1"};
         String m_localName{"LED Sign Controller"};
         bool m_secondaryModeEnabled{false};
+        bool m_proxyModeEnabled{false};
 };
 
 #endif

--- a/lib/Configuration/SystemConfiguration.cpp
+++ b/lib/Configuration/SystemConfiguration.cpp
@@ -328,6 +328,7 @@ BluetoothConfiguration SystemConfiguration::parseBluetoothConfiguration(JsonVari
     String uuid = defaultBtc.getUuid();
     String localName = defaultBtc.getLocalName();
     bool isSecondaryModeEnabled = defaultBtc.isSecondaryModeEnabled();
+    bool isProxyModeEnabled = defaultBtc.isProxyModeEnabled();
     
     if (btcVariant["enabled"].is<JsonVariant>())
     {
@@ -351,9 +352,15 @@ BluetoothConfiguration SystemConfiguration::parseBluetoothConfiguration(JsonVari
         isSecondaryModeEnabled = btcVariant["isSecondaryModeEnabled"].as<bool>();
     }
 
+    if (btcVariant["isProxyModeEnabled"].is<JsonVariant>())
+    {
+        isProxyModeEnabled = btcVariant["isProxyModeEnabled"].as<bool>();
+    }
+
     return BluetoothConfiguration(
         enabled,
         uuid,
         localName,
-        isSecondaryModeEnabled);
+        isSecondaryModeEnabled,
+        isProxyModeEnabled);
 }

--- a/lib/DisplayPatternLib/src/DisplayPattern.cpp
+++ b/lib/DisplayPatternLib/src/DisplayPattern.cpp
@@ -45,15 +45,15 @@ bool DisplayPattern::update(PixelMap* pixelMap)
     int consecutiveUpdates = 0;
     while (m_nextUpdate <= millis())
     {
-        m_nextUpdate += m_iterationDelay;
-        updateInternal(pixelMap);
-        consecutiveUpdates++;
         if (consecutiveUpdates >= 3)
         {
             // Prevent potential infinite loop if updates are taking too long.
             m_nextUpdate = millis() + m_iterationDelay;
             break;
         }
+        m_nextUpdate += m_iterationDelay;
+        updateInternal(pixelMap);
+        consecutiveUpdates++;
     }
 
     return true;


### PR DESCRIPTION
Add "secondary mode" flag to BT Config, use that to create either a "Common" or "Secondary" BT service.  Only update secondary attributes if secondary mode is enabled.