### PR TITLE
Simplifying Fire display logic

### DIFF
--- a/ArduinoSignController/src/Patterns/DisplayPatterns/DisplayPatternType.h
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/DisplayPatternType.h
@@ -17,8 +17,6 @@ enum class DisplayPatternType : byte
     Line = 9,
     LowPower = 10,
     Fire = 11,
-    Fire2 = 12,
-    Fire3 = 13,
     Rotation = 14,
     RotationCCW = 15,
     SpotLight = 16,
@@ -79,14 +77,6 @@ class DisplayPatternTypeHelper
             if (type.equalsIgnoreCase("fire") || type.equalsIgnoreCase(String((int)DisplayPatternType::Fire)))
             {
                 return DisplayPatternType::Fire;
-            }
-            if (type.equalsIgnoreCase("fire2") || type.equalsIgnoreCase(String((int)DisplayPatternType::Fire2)))
-            {
-                return DisplayPatternType::Fire2;
-            }
-            if (type.equalsIgnoreCase("fire3") || type.equalsIgnoreCase(String((int)DisplayPatternType::Fire3)))
-            {
-                return DisplayPatternType::Fire3;
             }
             if (type.equalsIgnoreCase("rotation") || type.equalsIgnoreCase(String((int)DisplayPatternType::Rotation)))
             {

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.cpp
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.cpp
@@ -26,10 +26,6 @@ void FireDisplayPattern::resetInternal(PixelMap* pixelMap)
         case FirePatternType::IndividualRows:
             populateCombinedGroupsForIndividualColumns(pixelMap);
             break;
-        case FirePatternType::Digit:
-            populateCombinedGroupsForDigits(pixelMap);
-            break;
-        case FirePatternType::Solid:
         default:
             populateAllRows(pixelMap);
             break;
@@ -111,25 +107,6 @@ void FireDisplayPattern::populateCombinedGroupsForIndividualColumns(PixelMap* pi
         }
 
         m_combinedRowGroups.push_back(rowGroup);
-    }
-}
-
-void FireDisplayPattern::populateCombinedGroupsForDigits(PixelMap* pixelMap)
-{
-    for (uint16_t digitNumber = 0; digitNumber < pixelMap->getDigitCount(); digitNumber++)
-    {
-        std::vector<std::vector<int>> digitRows;
-        for (std::vector<int>* row : pixelMap->getRowsForDigit(digitNumber))
-        {
-            std::vector<int> rowPixels;
-            for (int pixel : *row)
-            {
-                rowPixels.push_back(pixel);
-            }
-            digitRows.push_back(rowPixels);
-        }
-
-        m_combinedRowGroups.push_back(digitRows);
     }
 }
 

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.cpp
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.cpp
@@ -24,7 +24,7 @@ void FireDisplayPattern::resetInternal(PixelMap* pixelMap)
 
     // Initialize the row heat groups based on the row groupings
     // and set all the initial heats to 0
-    m_combinedRowHeats.clear();
+    m_rowHeats.clear();
     for (std::vector<std::vector<int>> rowGroup : m_combinedRowGroups)
     {
         std::vector<int> rowHeatsForGroup;
@@ -33,7 +33,7 @@ void FireDisplayPattern::resetInternal(PixelMap* pixelMap)
             rowHeatsForGroup.push_back(0);
         }
 
-        m_combinedRowHeats.push_back(rowHeatsForGroup);
+        m_rowHeats.push_back(rowHeatsForGroup);
     }
 }
 
@@ -41,11 +41,11 @@ void FireDisplayPattern::updateInternal(PixelMap* pixelMap)
 {
     for (int group = 0; group < m_combinedRowGroups.size(); group++)
     {
-        updateRowHeats(m_combinedRowHeats[group]);
-        int numRows = m_combinedRowHeats[group].size();
+        updateRowHeats(m_rowHeats[group]);
+        int numRows = m_rowHeats[group].size();
         for (int row = 0; row < numRows; row++)
         {
-            byte temperature = m_combinedRowHeats[group][row];
+            byte temperature = m_rowHeats[group][row];
             uint32_t color = m_heatColors[temperature];
             for (int pixel : m_combinedRowGroups[group][numRows - row - 1])
             {

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.cpp
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.cpp
@@ -18,70 +18,41 @@ void FireDisplayPattern::setCoolingAmount(byte coolingAmount)
 void FireDisplayPattern::resetInternal(PixelMap* pixelMap)
 {
     pixelMap->fill(0);
-    m_combinedRowGroups.clear();
 
-    populateCombinedGroupsForIndividualColumns(pixelMap);
+    int numRows = pixelMap->getRowCount();
+    int numCols = pixelMap->getColumnCount();
 
     // Initialize the row heat groups based on the row groupings
     // and set all the initial heats to 0
-    m_rowHeats.clear();
-    for (std::vector<std::vector<int>> rowGroup : m_combinedRowGroups)
+    m_heatMap.clear();
+    for (int col = 0; col < numCols; col++)
     {
-        std::vector<int> rowHeatsForGroup;
-        for (std::vector<int> rows : rowGroup)
+        std::vector<int> heatsForRow;
+        for (int row = 0; row < numRows; row++)
         {
-            rowHeatsForGroup.push_back(0);
+            heatsForRow.push_back(0);
         }
 
-        m_rowHeats.push_back(rowHeatsForGroup);
+        m_heatMap.push_back(heatsForRow);
     }
 }
 
 void FireDisplayPattern::updateInternal(PixelMap* pixelMap)
 {
-    for (int group = 0; group < m_combinedRowGroups.size(); group++)
+    for (int col = 0; col < m_heatMap.size(); col++)
     {
-        updateRowHeats(m_rowHeats[group]);
-        int numRows = m_rowHeats[group].size();
-        for (int row = 0; row < numRows; row++)
+        updateRowHeats(m_heatMap[col]);
+        int numRows = m_heatMap[col].size();
+
+        for (int row = 0; row < m_heatMap[col].size(); row++)
         {
-            byte temperature = m_rowHeats[group][row];
+            byte temperature = m_heatMap[col][row];
             uint32_t color = m_heatColors[temperature];
-            for (int pixel : m_combinedRowGroups[group][numRows - row - 1])
-            {
-                pixelMap->setRawPixelColor(pixel, color);
-            }
+
+            // Row 0 in the pixel map is on top, 
+            // row 0 in the heat map is on the bottom.
+            pixelMap->setColorInPixelMap(numRows - row, col, color);
         }
-    }
-}
-
-void FireDisplayPattern::populateCombinedGroupsForIndividualColumns(PixelMap* pixelMap)
-{
-    // Get the full list of columns and rows.
-    // Each column will be a grouping.
-    // Find what row each column's pixels are in to get the row mappings.
-    // If a column doesn't have a pixel in a specific row, add and empty pixel list for that row.
-    std::vector<std::vector<int>*> columns = pixelMap->getAllColumns();
-    std::vector<std::vector<int>*> rows = pixelMap->getAllRows();
-    
-    for(std::vector<int>* column : columns)
-    {
-        std::vector<std::vector<int>> rowGroup;
-        for (std::vector<int>* row : rows)
-        {
-            std::vector<int> pixelsInRow;
-            for (int pixel : *column)
-            {
-                if (std::find(row->begin(), row->end(), pixel) != row->end())
-                {
-                    pixelsInRow.push_back(pixel);
-                }
-            }
-
-            rowGroup.push_back(pixelsInRow);
-        }
-
-        m_combinedRowGroups.push_back(rowGroup);
     }
 }
 

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.cpp
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.cpp
@@ -20,15 +20,7 @@ void FireDisplayPattern::resetInternal(PixelMap* pixelMap)
     pixelMap->fill(0);
     m_combinedRowGroups.clear();
 
-    switch (m_patternType)
-    {
-        case FirePatternType::IndividualRows:
-            populateCombinedGroupsForIndividualColumns(pixelMap);
-            break;
-        default:
-            populateAllRows(pixelMap);
-            break;
-    }
+    populateCombinedGroupsForIndividualColumns(pixelMap);
 
     // Initialize the row heat groups based on the row groupings
     // and set all the initial heats to 0
@@ -61,22 +53,6 @@ void FireDisplayPattern::updateInternal(PixelMap* pixelMap)
             }
         }
     }
-}
-
-void FireDisplayPattern::populateAllRows(PixelMap* pixelMap)
-{
-    std::vector<std::vector<int>> allRows;
-    for (std::vector<int>* row : pixelMap->getAllRows())
-    {
-        std::vector<int> pixelsInRow;
-        for (int pixel : *row)
-        {
-            pixelsInRow.push_back(pixel);
-        }
-        allRows.push_back(pixelsInRow);
-    }
-
-    m_combinedRowGroups.push_back(allRows);
 }
 
 void FireDisplayPattern::populateCombinedGroupsForIndividualColumns(PixelMap* pixelMap)

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.cpp
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.cpp
@@ -1,8 +1,7 @@
 #include "FireDisplayPattern.h"
 
-FireDisplayPattern::FireDisplayPattern(FirePatternType patternType) : DisplayPattern()
+FireDisplayPattern::FireDisplayPattern() : DisplayPattern()
 {
-    m_patternType = patternType;
     generatePallet();
 }
 

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.h
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.h
@@ -25,8 +25,9 @@ class FireDisplayPattern : public DisplayPattern
         byte m_cooling{50};
         uint32_t m_heatColors[256];
         
-        // Maintains the current "heat" level for each row grouping.
-        std::vector<std::vector<int>> m_combinedRowHeats;
+        // Maintains the current "heat" level for the rows in each column.
+        // m_rowHeats[column][row] = heat_value
+        std::vector<std::vector<int>> m_rowHeats;
 
         // List of row groups (ex: digits), each of which contains a list of rows,
         // each of which contains the set of pixels in the row.

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.h
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.h
@@ -7,11 +7,6 @@
 #include "Utils\MathUtils.h"
 #include <vector>
 
-enum class FirePatternType : byte
-{
-    IndividualRows = 2
-};
-
 class FireDisplayPattern : public DisplayPattern
 {
     public:
@@ -26,7 +21,6 @@ class FireDisplayPattern : public DisplayPattern
         virtual void resetInternal(PixelMap* pixelMap);
 
     private:
-        FirePatternType m_patternType{FirePatternType::IndividualRows};
         byte m_sparking{120};
         byte m_cooling{50};
         uint32_t m_heatColors[256];
@@ -40,8 +34,6 @@ class FireDisplayPattern : public DisplayPattern
 
         void updateRowHeats(std::vector<int> &rowHeats);
         void generatePallet();
-        void populateAllRows(PixelMap* pixelMap);
-        void populateCombinedGroupsForDigits(PixelMap* pixelMap);
         void populateCombinedGroupsForIndividualColumns(PixelMap* pixelMap);
 };
 

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.h
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.h
@@ -9,8 +9,6 @@
 
 enum class FirePatternType : byte
 {
-    Solid = 0,
-    Digit = 1,
     IndividualRows = 2
 };
 
@@ -28,7 +26,7 @@ class FireDisplayPattern : public DisplayPattern
         virtual void resetInternal(PixelMap* pixelMap);
 
     private:
-        FirePatternType m_patternType{FirePatternType::Solid};
+        FirePatternType m_patternType{FirePatternType::IndividualRows};
         byte m_sparking{120};
         byte m_cooling{50};
         uint32_t m_heatColors[256];

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.h
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.h
@@ -15,7 +15,7 @@ enum class FirePatternType : byte
 class FireDisplayPattern : public DisplayPattern
 {
     public:
-        FireDisplayPattern(FirePatternType patternType);
+        FireDisplayPattern();
         void setSparkingAmount(byte sparkingAmount);
         void setCoolingAmount(byte coolingAmount);
 

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.h
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/FireDisplayPattern.h
@@ -23,19 +23,16 @@ class FireDisplayPattern : public DisplayPattern
     private:
         byte m_sparking{120};
         byte m_cooling{50};
+
+        // Maps the byte value of "temperature" to an actual RGB color value.
         uint32_t m_heatColors[256];
         
         // Maintains the current "heat" level for the rows in each column.
-        // m_rowHeats[column][row] = heat_value
-        std::vector<std::vector<int>> m_rowHeats;
-
-        // List of row groups (ex: digits), each of which contains a list of rows,
-        // each of which contains the set of pixels in the row.
-        std::vector<std::vector<std::vector<int>>> m_combinedRowGroups;
+        // m_heatMap[column][row] = heat_value
+        std::vector<std::vector<int>> m_heatMap;
 
         void updateRowHeats(std::vector<int> &rowHeats);
         void generatePallet();
-        void populateCombinedGroupsForIndividualColumns(PixelMap* pixelMap);
 };
 
 #endif

--- a/ArduinoSignController/src/Patterns/PatternFactory.cpp
+++ b/ArduinoSignController/src/Patterns/PatternFactory.cpp
@@ -95,24 +95,6 @@ DisplayPattern* PatternFactory::createForPatternData(const PatternData& patternD
             displayPattern = pattern;
             break;
         }
-        case DisplayPatternType::Fire3:
-        {
-            FireDisplayPattern* pattern = new FireDisplayPattern(FirePatternType::Solid);
-            pattern->setColorPattern(colorPattern);
-            pattern->setSparkingAmount(params[startOfDisplayParameters]);
-            pattern->setCoolingAmount(params[startOfDisplayParameters + 1]);
-            displayPattern = pattern;
-            break;
-        }
-        case DisplayPatternType::Fire2:
-        {
-            FireDisplayPattern* pattern = new FireDisplayPattern(FirePatternType::Digit);
-            pattern->setColorPattern(colorPattern);
-            pattern->setSparkingAmount(params[startOfDisplayParameters]);
-            pattern->setCoolingAmount(params[startOfDisplayParameters + 1]);
-            displayPattern = pattern;
-            break;
-        }
         case DisplayPatternType::Fire:
         {
             FireDisplayPattern* pattern = new FireDisplayPattern(FirePatternType::IndividualRows);

--- a/ArduinoSignController/src/Patterns/PatternFactory.cpp
+++ b/ArduinoSignController/src/Patterns/PatternFactory.cpp
@@ -97,7 +97,7 @@ DisplayPattern* PatternFactory::createForPatternData(const PatternData& patternD
         }
         case DisplayPatternType::Fire:
         {
-            FireDisplayPattern* pattern = new FireDisplayPattern(FirePatternType::IndividualRows);
+            FireDisplayPattern* pattern = new FireDisplayPattern();
             pattern->setColorPattern(colorPattern);
             pattern->setSparkingAmount(params[startOfDisplayParameters]);
             pattern->setCoolingAmount(params[startOfDisplayParameters + 1]);


### PR DESCRIPTION
Removing unused "digit" and "block" fire patterns.
Simplifying the remaining fire logic, utilization the pixel map's row/column structure.