### PR TITLE
Make exposed DisplayPatterns and ColorPatterns configurable

### DIFF
--- a/ArduinoSignController/src/Configuration/SystemConfiguration.cpp
+++ b/ArduinoSignController/src/Configuration/SystemConfiguration.cpp
@@ -35,6 +35,16 @@ SystemConfiguration* SystemConfiguration::ParseJson(
     config->m_displayConfigurationFile = JsonUtils::getValueOrDefault(configDoc, "displayConfigurationFile", config->m_displayConfigurationFile);
     config->m_styleConfigurationFile = JsonUtils::getValueOrDefault(configDoc, "styleConfigurationFile", config->m_styleConfigurationFile);
 
+    if (configDoc["publishedColorPatterns"].is<JsonVariant>())
+    {
+        config->m_publishedColorPatterns = config->getStringList(configDoc["publishedColorPatterns"]);
+    }
+
+    if (configDoc["publishedDisplayPatterns"].is<JsonVariant>())
+    {
+        config->m_publishedDisplayPatterns = config->getStringList(configDoc["publishedDisplayPatterns"]);
+    }
+
     JsonVariant buttonConfigs = configDoc["buttons"].as<JsonVariant>();
     if (buttonFactory != nullptr && !buttonConfigs.isNull())
     {

--- a/ArduinoSignController/src/Configuration/SystemConfiguration.h
+++ b/ArduinoSignController/src/Configuration/SystemConfiguration.h
@@ -32,6 +32,9 @@ class SystemConfiguration {
         String getStyleConfigurationFile() { return m_styleConfigurationFile; }
         float getClockMultiplier() { return m_clockMultiplier; }
 
+        std::vector<String>& getPublishedColorPatterns() { return m_publishedColorPatterns; }
+        std::vector<String>& getPublishedDisplayPatterns() { return m_publishedDisplayPatterns; }
+
         PowerLedConfiguration& getPowerLedConfiguration() { return m_powerLedConfiguration; }
         BatteryMonitorConfiguration& getBatteryMonitorConfiguration() { return m_batteryMonitorConfiguration; }
         Tm1637DisplayConfiguration& getTm1637DisplayConfiguration() { return m_tm1637DisplayConfiguration; }
@@ -48,6 +51,8 @@ class SystemConfiguration {
         BatteryMonitorConfiguration m_batteryMonitorConfiguration;
         Tm1637DisplayConfiguration m_tm1637DisplayConfiguration;
         BluetoothConfiguration m_bluetoothConfiguration;
+        std::vector<String> m_publishedColorPatterns;
+        std::vector<String> m_publishedDisplayPatterns;
 
         SystemConfiguration() {};
         void configureButtonProcessor(JsonVariant buttonConfigs, ButtonFactory buttonFactory);

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/RadialDisplayPattern.cpp
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/RadialDisplayPattern.cpp
@@ -93,3 +93,7 @@ void RadialDisplayPattern::updateInternal(PixelMap* pixelMap)
     }
 }
 
+std::vector<String> RadialDisplayPattern::getParameterNames()
+{
+    return std::vector<String>();
+}

--- a/ArduinoSignController/src/Patterns/DisplayPatterns/RadialDisplayPattern.h
+++ b/ArduinoSignController/src/Patterns/DisplayPatterns/RadialDisplayPattern.h
@@ -10,6 +10,8 @@ class RadialDisplayPattern : public DisplayPattern {
     public:
         RadialDisplayPattern();
 
+        static std::vector<String> getParameterNames();
+
     protected:
         virtual void updateInternal(PixelMap* pixelMap) override;
         virtual void resetInternal(PixelMap* pixelMap) override;

--- a/ArduinoSignController/src/Patterns/PatternFactory.cpp
+++ b/ArduinoSignController/src/Patterns/PatternFactory.cpp
@@ -1,5 +1,8 @@
 #include "PatternFactory.h"
 
+std::unordered_map<ColorPatternType, String> PatternFactory::colorPatternStringLookup;
+std::unordered_map<DisplayPatternType, String> PatternFactory::displayPatternStringLookup;
+
 DisplayPattern* PatternFactory::createForPatternData(const PatternData& patternData)
 {
     std::vector<byte> params;
@@ -235,6 +238,46 @@ String PatternFactory::getKnownColorPatterns()
     return knownPatterns;
 }
 
+String PatternFactory::generateColorPatternString(const std::vector<String>& colorPatterns)
+{
+    populateColorPatternStringLookup();
+    String patternString;
+
+    for (uint16_t i = 0; i < colorPatterns.size(); i++)
+    {
+        ColorPatternType patternType = ColorPatternTypeHelper::fromString(colorPatterns[i]);
+
+        if (colorPatternStringLookup.find(patternType) == colorPatternStringLookup.end())
+        {
+            // Not found - just skip it.
+            continue;
+        }
+
+        patternString += colorPatternStringLookup[patternType] + ";";
+    }
+
+    return patternString;
+}
+
+String PatternFactory::generateDisplayPatternString(const std::vector<String>& displayPatterns)
+{
+    populateDisplayPatternStringLookup();
+    String patternString;
+    for (uint16_t i = 0; i < displayPatterns.size(); i++)
+    {
+        DisplayPatternType patternType = DisplayPatternTypeHelper::fromString(displayPatterns[i]);
+
+        if (displayPatternStringLookup.find(patternType) == displayPatternStringLookup.end())
+        {
+            continue;
+        }
+
+        patternString += displayPatternStringLookup[patternType] + ";";
+    }
+
+    return patternString;
+}
+
 String PatternFactory::getKnownDisplayPatterns()
 {
     String knownPatterns;
@@ -255,7 +298,7 @@ String PatternFactory::getKnownDisplayPatterns()
     return knownPatterns;
 }
 
-String PatternFactory::getColorPatternString(String patternName, ColorPatternType patternType, uint16_t numberOfColors, std::vector<String> parameterNames)
+String PatternFactory::getColorPatternString(String patternName, ColorPatternType patternType, uint16_t numberOfColors, const std::vector<String>& parameterNames)
 {
     // Format:
     // <name>,<number>,<#colors>,<param1>,...
@@ -271,7 +314,7 @@ String PatternFactory::getColorPatternString(String patternName, ColorPatternTyp
     return patternString;
 }
 
-String PatternFactory::getDisplayPatternString(String patternName, DisplayPatternType patternType, std::vector<String> parameterNames)
+String PatternFactory::getDisplayPatternString(String patternName, DisplayPatternType patternType, const std::vector<String>& parameterNames)
 {
     // Format:
     // <name>,<number>,<#colors>,<param1>,...
@@ -284,4 +327,42 @@ String PatternFactory::getDisplayPatternString(String patternName, DisplayPatter
     }
 
     return patternString;
+}
+
+void PatternFactory::populateColorPatternStringLookup()
+{
+    if (colorPatternStringLookup.size() == 0)
+    {
+        colorPatternStringLookup[ColorPatternType::SingleColor] = getColorPatternString("Single Color", ColorPatternType::SingleColor, 1, SingleColorPattern::getParameterNames());
+        colorPatternStringLookup[ColorPatternType::TwoColor] = getColorPatternString("Two Color", ColorPatternType::TwoColor, 2, TwoColorPattern::getParameterNames());
+        colorPatternStringLookup[ColorPatternType::TwoColorFade] = getColorPatternString("Two Color Fade", ColorPatternType::TwoColorFade, 2, ColorFadePattern::getParameterNames());
+        colorPatternStringLookup[ColorPatternType::ThreeColorFade] = getColorPatternString("Three Color Fade", ColorPatternType::ThreeColorFade, 3, ColorFadePattern::getParameterNames());
+        colorPatternStringLookup[ColorPatternType::FourColorFade] = getColorPatternString("Four Color Fade", ColorPatternType::FourColorFade, 4, ColorFadePattern::getParameterNames());
+        colorPatternStringLookup[ColorPatternType::BackgroundPlusThree] = getColorPatternString("Background+3", ColorPatternType::BackgroundPlusThree, 4, BackgroundPlusThree::getParameterNames());
+        colorPatternStringLookup[ColorPatternType::Rainbow] = getColorPatternString("Rainbow", ColorPatternType::Rainbow, 0, RainbowColorPattern::getParameterNames());
+    }
+}
+
+void PatternFactory::populateDisplayPatternStringLookup()
+{
+    if (displayPatternStringLookup.size() == 0)
+    {
+        displayPatternStringLookup[DisplayPatternType::Solid] = getDisplayPatternString("Solid", DisplayPatternType::Solid, SolidDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::Right] = getDisplayPatternString("Right", DisplayPatternType::Right, SimpleShiftDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::Left] = getDisplayPatternString("Left", DisplayPatternType::Left, SimpleShiftDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::Up] = getDisplayPatternString("Up", DisplayPatternType::Up, SimpleShiftDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::Down] = getDisplayPatternString("Down", DisplayPatternType::Down, SimpleShiftDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::Digit] = getDisplayPatternString("Digit", DisplayPatternType::Digit, SimpleShiftDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::Random] = getDisplayPatternString("Random", DisplayPatternType::Random, RandomDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::CenterOutVertical] = getDisplayPatternString("CenterOut-V", DisplayPatternType::CenterOutVertical, CenterOutDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::CenterOutHorizontal] = getDisplayPatternString("CenterOut", DisplayPatternType::CenterOutHorizontal, CenterOutDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::Line] = getDisplayPatternString("Line", DisplayPatternType::Line, SimpleShiftDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::Fire] = getDisplayPatternString("Fire", DisplayPatternType::Fire, FireDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::Rotation] = getDisplayPatternString("Rotation", DisplayPatternType::Rotation, RotationDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::RotationCCW] = getDisplayPatternString("RotationCCW", DisplayPatternType::RotationCCW, RotationDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::SpotLight] = getDisplayPatternString("SpotLight", DisplayPatternType::SpotLight, RotationDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::SpotLightCCW] = getDisplayPatternString("SpotLightCCW", DisplayPatternType::SpotLightCCW, RotationDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::CenterOutSquare] = getDisplayPatternString("CenterOutSquare", DisplayPatternType::CenterOutSquare, CenterOutDisplayPattern::getParameterNames());
+        displayPatternStringLookup[DisplayPatternType::Radial] = getDisplayPatternString("Radial", DisplayPatternType::Radial, RadialDisplayPattern::getParameterNames());
+    }
 }

--- a/ArduinoSignController/src/Patterns/PatternFactory.h
+++ b/ArduinoSignController/src/Patterns/PatternFactory.h
@@ -19,6 +19,7 @@
 #include "ColorPatterns\BackgroundPlusThree.h"
 #include "PatternData.h"
 #include <vector>
+#include <unordered_map>
 
 class PatternFactory
 {
@@ -32,18 +33,26 @@ class PatternFactory
         // the string representation later.  Since there's only one user of this method currently, just
         // take the simpler approach and calculate the string value here.
         static String getKnownColorPatterns();
+        static String generateColorPatternString(const std::vector<String>& colorPatterns);
 
         // Retrieves a string version of all known color patterns.
         // This is in the format <PatternName>,<PatternNumber>,<param1>,...,<paramN>;<PatternName>,<PatternNumber>,<param1>,...,<paramN>;...
         // Similar to getKnownColorPatterns above, this could also return a vector of information structs.
         static String getKnownDisplayPatterns();
+        static String generateDisplayPatternString(const std::vector<String>& displayPatterns);
 
     private:
         // Helper method to construct the appropriate ColorPattern based on the given PatternData.
         static ColorPattern* createColorPatternForPatternData(const PatternData& patternData);
 
-        static String getColorPatternString(String patternName, ColorPatternType patternType, uint16_t numberOfColors, std::vector<String> parameterNames);
-        static String getDisplayPatternString(String patternName, DisplayPatternType patternType, std::vector<String> parameterNames);
+        static String getColorPatternString(String patternName, ColorPatternType patternType, uint16_t numberOfColors, const std::vector<String>& parameterNames);
+        static String getDisplayPatternString(String patternName, DisplayPatternType patternType, const std::vector<String>& parameterNames);
+
+        static std::unordered_map<ColorPatternType, String> colorPatternStringLookup;
+        static std::unordered_map<DisplayPatternType, String> displayPatternStringLookup;
+
+        static void populateColorPatternStringLookup();
+        static void populateDisplayPatternStringLookup();
 };
 
 #endif

--- a/ArduinoSignController/src/main.cpp
+++ b/ArduinoSignController/src/main.cpp
@@ -400,9 +400,27 @@ void initializeBlePeripheralService()
     blePeripheralService->setBrightness(currentBrightness);
     blePeripheralService->setSpeed(currentSpeed);
     blePeripheralService->setPatternData(currentPatternData);
-    blePeripheralService->setColorPatternList(PatternFactory::getKnownColorPatterns());
-    blePeripheralService->setDisplayPatternList(PatternFactory::getKnownDisplayPatterns());
+
+    String colorPatternList = PatternFactory::generateColorPatternString(
+            systemConfiguration->getPublishedColorPatterns().size() > 0 ?
+                systemConfiguration->getPublishedColorPatterns() :
+                DefaultColorPatterns);
+
+    Serial.println("Published color pattern list:");
+    Serial.println(colorPatternList);
+
+    blePeripheralService->setColorPatternList(colorPatternList);
     
+    String displayPatternList = PatternFactory::generateDisplayPatternString(
+            systemConfiguration->getPublishedDisplayPatterns().size() > 0 ?
+                systemConfiguration->getPublishedDisplayPatterns() :
+                DefaultDisplayPatterns);
+        
+    Serial.println("Published display pattern list:");
+    Serial.println(displayPatternList);
+
+    blePeripheralService->setDisplayPatternList(displayPatternList);
+
     if (bluetoothConfig.isSecondaryModeEnabled())
     {
         SignConfigurationData signConfigData;

--- a/ArduinoSignController/src/main.cpp
+++ b/ArduinoSignController/src/main.cpp
@@ -9,6 +9,7 @@ StyleConfiguration* styleConfiguration = nullptr;
 BatteryMonitorConfiguration batteryMonitorConfig;
 PowerLedConfiguration powerLedConfig;
 BluetoothConfiguration bluetoothConfig;
+SystemConfiguration* systemConfiguration;
 
 ulong loopCounter = 0;
 ulong lastTelemetryTimestamp = 0;
@@ -35,7 +36,6 @@ std::vector<SecondaryClient *> allSecondaries;
 ulong nextSecondaryConnectionCheck = 0;
 
 volatile bool isInitialized = false;
-SystemConfiguration* systemConfiguration;
 
 void setup()
 {

--- a/ArduinoSignController/src/main.h
+++ b/ArduinoSignController/src/main.h
@@ -73,6 +73,11 @@ void updateAllSecondaries();
 void checkSecondaryConnections();
 void resetSecondaryConnections();
 
+// Default values
+std::vector<String> DefaultColorPatterns {"SingleColor","TwoColor","Rainbow", "BackgroundPlusThree"};
+std::vector<String> DefaultDisplayPatterns {"Solid","Right","Digit","Random","Line","Fire","Spotlight","Radial"};
+
+// JSON configs for signs that can't read from the SD card.
 const char* defaultSystemConfigJsonForSecondaries = R"json(
     {
         "displayConfigurationFile": "::Display[[SIGNTYPE1]]::",

--- a/ArduinoSignController/test/test_SystemConfiguration/SystemConfigurationTests.cpp
+++ b/ArduinoSignController/test/test_SystemConfiguration/SystemConfigurationTests.cpp
@@ -324,10 +324,10 @@ const char* configWithPublishSettings() {
     return R"json(
         {
             "displayConfigurationFile": "display.json",
-            "styleConfigurationFile": "styles.json"
-        },
-        "publishedColorPatterns": ["TwoColor", "Rainbow"],
-        "publishedDisplayPatterns": ["Right", "Fire"]
+            "styleConfigurationFile": "styles.json",
+            "publishedColorPatterns": ["TwoColor", "Rainbow"],
+            "publishedDisplayPatterns": ["Right", "Fire"]
+        }
     )json";
 }
 

--- a/ArduinoSignController/test/test_SystemConfiguration/SystemConfigurationTests.cpp
+++ b/ArduinoSignController/test/test_SystemConfiguration/SystemConfigurationTests.cpp
@@ -30,6 +30,7 @@ const char* oneButtonWithActions();
 const char* buttonsWithActions();
 const char* disabledButton();
 const char* additionalConfigurations();
+const char* configWithPublishSettings();
 
 void resetActionParameters() {
     lastCallerId = -1;
@@ -276,6 +277,26 @@ void additionalConfigurationsAreParsed() {
     delete sc;
 }
 
+void publishedPatternsAreParsed() {
+    String json = configWithPublishSettings();
+    SystemConfiguration* sc = SystemConfiguration::ParseJson(
+        json.c_str(), 
+        json.length(), 
+        mockButtonFactory);
+    
+    TEST_ASSERT_TRUE_MESSAGE(sc->isValid(), "SystemConfiguration should be valid.");
+    std::vector<String> publishedColorPatterns = sc->getPublishedColorPatterns();
+    TEST_ASSERT_EQUAL_MESSAGE(2, publishedColorPatterns.size(), "There should be 2 published color patterns.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("TwoColor", publishedColorPatterns[0].c_str(), "First published color pattern is not correct.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Rainbow", publishedColorPatterns[1].c_str(), "Second published color pattern is not correct.");
+    std::vector<String> publishedDisplayPatterns = sc->getPublishedDisplayPatterns();
+    TEST_ASSERT_EQUAL_MESSAGE(2, publishedDisplayPatterns.size(), "There should be 2 published display patterns.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Right", publishedDisplayPatterns[0].c_str(), "First published display pattern is not correct.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("Fire", publishedDisplayPatterns[1].c_str(), "Second published display pattern is not correct.");
+
+    delete sc;
+}
+
 int main(int argc, char **argv) {
     UNITY_BEGIN();
 
@@ -286,7 +307,7 @@ int main(int argc, char **argv) {
     RUN_TEST(buttonsAndActionsAreParsed);
     RUN_TEST(disabledButtonDefinitionIsIgnored);
     RUN_TEST(additionalConfigurationsAreParsed);
-
+    RUN_TEST(publishedPatternsAreParsed);
     return UNITY_END();
 }
 
@@ -296,6 +317,17 @@ const char* minimalConfigurationJson() {
             "displayConfigurationFile": "display.json",
             "styleConfigurationFile": "styles.json"
         }
+    )json";
+}
+
+const char* configWithPublishSettings() {
+    return R"json(
+        {
+            "displayConfigurationFile": "display.json",
+            "styleConfigurationFile": "styles.json"
+        },
+        "publishedColorPatterns": ["TwoColor", "Rainbow"],
+        "publishedDisplayPatterns": ["Right", "Fire"]
     )json";
 }
 

--- a/Configs/Primary/styleconfiguration.json
+++ b/Configs/Primary/styleconfiguration.json
@@ -66,6 +66,13 @@
             "param1": 100,
             "param2": 100,
             "param3": 200
+        },
+        {
+            "name": "RainbowRight",
+            "colorPattern": "Rainbow",
+            "displayPattern": "Right",
+            "speed": 255,
+            "param1": 120
         }
     ]
 }

--- a/Configs/Primary/systemconfiguration.json
+++ b/Configs/Primary/systemconfiguration.json
@@ -62,6 +62,8 @@
             }
         ]
     },
+    "publishedColorPatterns": [],
+    "publishedDisplayPatterns": [],
     "batteryMonitor": {
         "enabled": false,
         "analogInputGpioPin": 29,

--- a/Configs/Primary/systemconfiguration.json
+++ b/Configs/Primary/systemconfiguration.json
@@ -9,6 +9,8 @@
         "isProxyModeEnabled": true,
         "proxyClientUuid": "1221ca8d-4172-4946-bcd1-f9e4b40ba6b0"
     },
+    "publishedColorPatterns": ["SingleColor", "TwoColor", "BackgroundPlusThree", "Rainbow"],
+    "publishedDisplayPatterns": ["Solid", "Right", "Digit", "Random", "Line", "Radial", "Spotlight", "Fire"],
     "buttons": {
         "definitions": [
             {
@@ -62,8 +64,6 @@
             }
         ]
     },
-    "publishedColorPatterns": [],
-    "publishedDisplayPatterns": [],
     "batteryMonitor": {
         "enabled": false,
         "analogInputGpioPin": 29,


### PR DESCRIPTION
The BLE characteristics that tell the Android app what display patterns and color patterns to show are now configurable and driven by the JSON file.  If not present, a default set is used.